### PR TITLE
fix: cacheControl header when uploading

### DIFF
--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -42,10 +42,10 @@ export class StorageFileApi {
       if (!isBrowser()) throw new Error('No browser detected.')
 
       const formData = new FormData()
-      formData.append('', file, file.name)
 
       const options = { ...DEFAULT_FILE_OPTIONS, ...fileOptions }
       formData.append('cacheControl', options.cacheControl)
+      formData.append('', file, file.name)
 
       const _path = this._getFinalPath(path)
       const res = await fetch(`${this.url}/object/${_path}`, {
@@ -83,10 +83,10 @@ export class StorageFileApi {
       if (!isBrowser()) throw new Error('No browser detected.')
 
       const formData = new FormData()
-      formData.append('', file, file.name)
 
       const options = { ...DEFAULT_FILE_OPTIONS, ...fileOptions }
       formData.append('cacheControl', options.cacheControl)
+      formData.append('', file, file.name)
 
       const _path = this._getFinalPath(path)
       const res = await fetch(`${this.url}/object/${_path}`, {


### PR DESCRIPTION
fixes https://github.com/supabase/storage-api/issues/18

Looks like the non file values need to be sent before the file fields in form-data as mentioned [here](https://github.com/fastify/fastify-multipart/issues/146#issuecomment-681874488) and it is the intended behaviour. 