### PR TITLE
feat: Added a method to get public URL of an object

### DIFF
--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -179,6 +179,29 @@ export class StorageFileApi {
   }
 
   /**
+   * Downloads a file.
+   *
+   * @param path The file path to be downloaded, including the path and file name. For example `folder/image.png`.
+   */
+  async getPublicUrl(
+    path: string
+  ): Promise<{
+    data: { publicURL: string } | null
+    error: Error | null
+    publicURL: string | null
+  }> {
+    try {
+      const _path = this._getFinalPath(path)
+      let publicURL = `/object/public/${_path}`
+      const data = { publicURL }
+      publicURL = `${this.url}${publicURL}`
+      return { data, error: null, publicURL }
+    } catch (error) {
+      return { data: null, error, publicURL: null }
+    }
+  }
+
+  /**
    * Deletes files within the same bucket
    *
    * @param paths An array of files to be deletes, including the path and file name. For example [`folder/image.png`].

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -179,7 +179,7 @@ export class StorageFileApi {
   }
 
   /**
-   * Returns a publicly accessible URL
+   * Retrieve URLs for assets in public buckets
    *
    * @param path The file path to be downloaded, including the path and file name. For example `folder/image.png`.
    */

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -179,17 +179,17 @@ export class StorageFileApi {
   }
 
   /**
-   * Downloads a file.
+   * Returns a publicly accessible URL
    *
    * @param path The file path to be downloaded, including the path and file name. For example `folder/image.png`.
    */
-  async getPublicUrl(
+  getPublicUrl(
     path: string
-  ): Promise<{
+  ): {
     data: { publicURL: string } | null
     error: Error | null
     publicURL: string | null
-  }> {
+  } {
     try {
       const _path = this._getFinalPath(path)
       let publicURL = `/object/public/${_path}`

--- a/test/__snapshots__/storageFileApi.test.ts.snap
+++ b/test/__snapshots__/storageFileApi.test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`get public URL 1`] = `
 Object {
-  "publicURL": "/object/public/my-new-bucket-1622499505045/profiles/myUniqueUserId/profile.png",
+  "publicURL": "/object/public/my-new-public-bucket/profiles/myUniqueUserId/profile.png",
 }
 `;
 
-exports[`get public URL 2`] = `"http://localhost:8000/storage/v1/object/public/my-new-bucket-1622499505045/profiles/myUniqueUserId/profile.png"`;
+exports[`get public URL 2`] = `"http://localhost:8000/storage/v1/object/public/my-new-public-bucket/profiles/myUniqueUserId/profile.png"`;

--- a/test/__snapshots__/storageFileApi.test.ts.snap
+++ b/test/__snapshots__/storageFileApi.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`get public URL 1`] = `
+Object {
+  "publicURL": "/object/public/my-new-bucket-1622499505045/profiles/myUniqueUserId/profile.png",
+}
+`;
+
+exports[`get public URL 2`] = `"http://localhost:8000/storage/v1/object/public/my-new-bucket-1622499505045/profiles/myUniqueUserId/profile.png"`;

--- a/test/storageFileApi.test.ts
+++ b/test/storageFileApi.test.ts
@@ -6,7 +6,7 @@ const KEY =
   'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzdXBhYmFzZSIsImlhdCI6MTYwMzk2ODgzNCwiZXhwIjoyNTUwNjUzNjM0LCJhdWQiOiIiLCJzdWIiOiIzMTdlYWRjZS02MzFhLTQ0MjktYTBiYi1mMTlhN2E1MTdiNGEiLCJSb2xlIjoicG9zdGdyZXMifQ.pZobPtp6gDcX0UbzMmG3FHSlg4m4Q-22tKtGWalOrNo'
 
 const storage = new SupabaseStorageClient(URL, { Authorization: `Bearer ${KEY}` })
-const newBucketName = `my-new-bucket-${Date.now()}`
+const newBucketName = 'my-new-public-bucket'
 
 test('get public URL', async () => {
   const res = storage.from(newBucketName).getPublicUrl('profiles/myUniqueUserId/profile.png')

--- a/test/storageFileApi.test.ts
+++ b/test/storageFileApi.test.ts
@@ -1,0 +1,16 @@
+import { SupabaseStorageClient } from '../src/index'
+
+// TODO: need to setup storage-api server for this test
+const URL = 'http://localhost:8000/storage/v1'
+const KEY =
+  'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzdXBhYmFzZSIsImlhdCI6MTYwMzk2ODgzNCwiZXhwIjoyNTUwNjUzNjM0LCJhdWQiOiIiLCJzdWIiOiIzMTdlYWRjZS02MzFhLTQ0MjktYTBiYi1mMTlhN2E1MTdiNGEiLCJSb2xlIjoicG9zdGdyZXMifQ.pZobPtp6gDcX0UbzMmG3FHSlg4m4Q-22tKtGWalOrNo'
+
+const storage = new SupabaseStorageClient(URL, { Authorization: `Bearer ${KEY}` })
+const newBucketName = `my-new-bucket-${Date.now()}`
+
+test('get public URL', async () => {
+  const res = storage.from(newBucketName).getPublicUrl('profiles/myUniqueUserId/profile.png')
+  expect(res.error).toBeNull()
+  expect(res.data).toMatchSnapshot()
+  expect(res.publicURL).toMatchSnapshot()
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Introducing a new feature to add a method to easily retrieve public URLs of object uploaded to storage. 

Related PR on storage-api
https://github.com/supabase/storage-api/pull/19

## What is the current behavior?

There is not an easy way of getting a public URL of an object. 

## What is the new behavior?

There will be a method where you can just pass the bucket and the path, and it will return full URL of the object. 

## Additional context

I don't know if we need a method like this when all it is doing is just concatenating Supabase URL, bucket name, and path with '/object/public' in the middle, but personally I would appreciate if the SDK could handle the concatenation. 

Also, I was not sure if implementing something like this has been discussed internally, so if there is already a plan for it, and is different from the code that I wrote, please feel free to just close this PR. 

Otherwise, any feedback is greatly appreciated! 