### PR TITLE
feat: Added public option to createBucket method

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       PGRST_DB_ANON_ROLE: postgres
       PGRST_JWT_SECRET: super-secret-jwt-token-with-at-least-32-characters-long
   storage:
-    image: supabase/storage-api:v0.2.1
+    image: supabase/storage-api:v0.3.1
     ports:
       - '5000:5000'
     depends_on:

--- a/infra/postgres/storage-schema.sql
+++ b/infra/postgres/storage-schema.sql
@@ -12,7 +12,7 @@ CREATE TABLE "storage"."buckets" (
     "owner" uuid,
     "created_at" timestamptz DEFAULT now(),
     "updated_at" timestamptz DEFAULT now(),
-    "public" boolean default false,
+    "public" boolean DEFAULT false,
     CONSTRAINT "buckets_owner_fkey" FOREIGN KEY ("owner") REFERENCES "auth"."users"("id"),
     PRIMARY KEY ("id")
 );

--- a/infra/postgres/storage-schema.sql
+++ b/infra/postgres/storage-schema.sql
@@ -12,7 +12,6 @@ CREATE TABLE "storage"."buckets" (
     "owner" uuid,
     "created_at" timestamptz DEFAULT now(),
     "updated_at" timestamptz DEFAULT now(),
-    "public" boolean DEFAULT false,
     CONSTRAINT "buckets_owner_fkey" FOREIGN KEY ("owner") REFERENCES "auth"."users"("id"),
     PRIMARY KEY ("id")
 );

--- a/infra/postgres/storage-schema.sql
+++ b/infra/postgres/storage-schema.sql
@@ -12,6 +12,7 @@ CREATE TABLE "storage"."buckets" (
     "owner" uuid,
     "created_at" timestamptz DEFAULT now(),
     "updated_at" timestamptz DEFAULT now(),
+    "public" boolean default false,
     CONSTRAINT "buckets_owner_fkey" FOREIGN KEY ("owner") REFERENCES "auth"."users"("id"),
     PRIMARY KEY ("id")
 );

--- a/src/lib/StorageBucketApi.ts
+++ b/src/lib/StorageBucketApi.ts
@@ -1,4 +1,4 @@
-import { get, post, remove } from './fetch'
+import { get, post, put, remove } from './fetch'
 import { Bucket } from './types'
 
 export class StorageBucketApi {
@@ -53,6 +53,27 @@ export class StorageBucketApi {
         { headers: this.headers }
       )
       return { data: data.name, error: null }
+    } catch (error) {
+      return { data: null, error }
+    }
+  }
+
+  /**
+   * Updates a new Storage bucket
+   *
+   * @param id A unique identifier for the bucket you are creating.
+   */
+  async updateBucket(
+    id: string,
+    options: { public: boolean }
+  ): Promise<{ data: { message: string } | null; error: Error | null }> {
+    try {
+      const data = await put(
+        `${this.url}/bucket/${id}`,
+        { id, name: id, public: options.public },
+        { headers: this.headers }
+      )
+      return { data, error: null }
     } catch (error) {
       return { data: null, error }
     }

--- a/src/lib/StorageBucketApi.ts
+++ b/src/lib/StorageBucketApi.ts
@@ -42,9 +42,16 @@ export class StorageBucketApi {
    * @param id A unique identifier for the bucket you are creating.
    * @returns newly created bucket id
    */
-  async createBucket(id: string): Promise<{ data: string | null; error: Error | null }> {
+  async createBucket(
+    id: string,
+    options: { public: boolean } = { public: false }
+  ): Promise<{ data: string | null; error: Error | null }> {
     try {
-      const data = await post(`${this.url}/bucket`, { id, name: id }, { headers: this.headers })
+      const data = await post(
+        `${this.url}/bucket`,
+        { id, name: id, public: options.public },
+        { headers: this.headers }
+      )
       return { data: data.name, error: null }
     } catch (error) {
       return { data: null, error }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,6 +4,7 @@ export interface Bucket {
   owner: string
   created_at: string
   updated_at: string
+  public: boolean
 }
 
 export interface FileObject {

--- a/test/__snapshots__/storageApi.test.ts.snap
+++ b/test/__snapshots__/storageApi.test.ts.snap
@@ -43,7 +43,7 @@ Object {
   "id": "bucket2",
   "name": "bucket2",
   "owner": "4d56e902-f0a0-4662-8448-a4d9e643c142",
-    "public": false,
+  "public": false,
   "updated_at": "2021-02-17T04:43:32.770206+00:00",
 }
 `;

--- a/test/__snapshots__/storageApi.test.ts.snap
+++ b/test/__snapshots__/storageApi.test.ts.snap
@@ -7,6 +7,7 @@ Array [
     "id": "bucket2",
     "name": "bucket2",
     "owner": "4d56e902-f0a0-4662-8448-a4d9e643c142",
+    "public": false,
     "updated_at": "2021-02-17T04:43:32.770206+00:00",
   },
   Object {
@@ -14,6 +15,7 @@ Array [
     "id": "bucket3",
     "name": "bucket3",
     "owner": "4d56e902-f0a0-4662-8448-a4d9e643c142",
+    "public": false,
     "updated_at": "2021-02-17T04:43:32.770206+00:00",
   },
   Object {
@@ -21,6 +23,7 @@ Array [
     "id": "bucket4",
     "name": "bucket4",
     "owner": "317eadce-631a-4429-a0bb-f19a7a517b4a",
+    "public": false,
     "updated_at": "2021-02-25T09:23:01.58385+00:00",
   },
   Object {
@@ -28,6 +31,7 @@ Array [
     "id": "bucket5",
     "name": "bucket5",
     "owner": "317eadce-631a-4429-a0bb-f19a7a517b4a",
+    "public": false,
     "updated_at": "2021-02-27T03:04:25.6386+00:00",
   },
 ]
@@ -39,6 +43,7 @@ Object {
   "id": "bucket2",
   "name": "bucket2",
   "owner": "4d56e902-f0a0-4662-8448-a4d9e643c142",
+    "public": false,
   "updated_at": "2021-02-17T04:43:32.770206+00:00",
 }
 `;
@@ -47,16 +52,6 @@ exports[`Get bucket with wrong id 1`] = `
 Object {
   "message": "The resource was not found",
   "status": 400,
-}
-`;
-
-exports[`create new public bucket 1`] = `
-Object {
-  "created_at": "2021-05-31T23:05:11.103209+00:00",
-  "id": "my-new-public-bucket-1622502310904",
-  "name": "my-new-public-bucket-1622502310904",
-  "owner": "317eadce-631a-4429-a0bb-f19a7a517b4a",
-  "updated_at": "2021-05-31T23:05:11.103209+00:00",
 }
 `;
 

--- a/test/__snapshots__/storageApi.test.ts.snap
+++ b/test/__snapshots__/storageApi.test.ts.snap
@@ -50,6 +50,16 @@ Object {
 }
 `;
 
+exports[`create new public bucket 1`] = `
+Object {
+  "created_at": "2021-05-31T23:05:11.103209+00:00",
+  "id": "my-new-public-bucket-1622502310904",
+  "name": "my-new-public-bucket-1622502310904",
+  "owner": "317eadce-631a-4429-a0bb-f19a7a517b4a",
+  "updated_at": "2021-05-31T23:05:11.103209+00:00",
+}
+`;
+
 exports[`delete bucket 1`] = `
 Object {
   "message": "Successfully deleted",

--- a/test/__snapshots__/storageApi.test.ts.snap
+++ b/test/__snapshots__/storageApi.test.ts.snap
@@ -66,3 +66,9 @@ Object {
   "message": "Successfully emptied",
 }
 `;
+
+exports[`update bucket 1`] = `
+Object {
+  "message": "Successfully updated",
+}
+`;

--- a/test/storageApi.test.ts
+++ b/test/storageApi.test.ts
@@ -7,6 +7,7 @@ const KEY =
 
 const storage = new StorageBucketApi(URL, { Authorization: `Bearer ${KEY}` })
 const newBucketName = `my-new-bucket-${Date.now()}`
+const newPublicBucketName = `my-new-public-bucket-${Date.now()}`
 
 test('Build to succeed', async () => {
   // Basic test to ensure TS build is working.
@@ -32,6 +33,12 @@ test('Get bucket with wrong id', async () => {
 test('create new bucket', async () => {
   const res = await storage.createBucket(newBucketName)
   expect(res.data).toEqual(newBucketName)
+})
+
+test('create new public bucket', async () => {
+  await storage.createBucket(newPublicBucketName, { public: true })
+  const res = await storage.getBucket(newPublicBucketName)
+  expect(res.data).toMatchSnapshot()
 })
 
 test('empty bucket', async () => {

--- a/test/storageApi.test.ts
+++ b/test/storageApi.test.ts
@@ -38,7 +38,7 @@ test('create new public bucket', async () => {
   const newPublicBucketName = 'my-new-public-bucket'
   await storage.createBucket(newPublicBucketName, { public: true })
   const res = await storage.getBucket(newPublicBucketName)
-  expect(res.data.public).toBe(true)
+  expect(res.data!.public).toBe(true)
 })
 
 test('empty bucket', async () => {

--- a/test/storageApi.test.ts
+++ b/test/storageApi.test.ts
@@ -41,6 +41,14 @@ test('create new public bucket', async () => {
   expect(res.data!.public).toBe(true)
 })
 
+test('update bucket', async () => {
+  const updateRes = await storage.updateBucket(newBucketName, { public: true })
+  expect(updateRes.error).toBeNull()
+  expect(updateRes.data).toMatchSnapshot()
+  const getRes = await storage.getBucket(newBucketName)
+  expect(getRes.data!.public).toBe(true)
+})
+
 test('empty bucket', async () => {
   const res = await storage.emptyBucket(newBucketName)
   expect(res.error).toBeNull()

--- a/test/storageApi.test.ts
+++ b/test/storageApi.test.ts
@@ -7,7 +7,6 @@ const KEY =
 
 const storage = new StorageBucketApi(URL, { Authorization: `Bearer ${KEY}` })
 const newBucketName = `my-new-bucket-${Date.now()}`
-const newPublicBucketName = `my-new-public-bucket-${Date.now()}`
 
 test('Build to succeed', async () => {
   // Basic test to ensure TS build is working.
@@ -36,9 +35,10 @@ test('create new bucket', async () => {
 })
 
 test('create new public bucket', async () => {
+  const newPublicBucketName = 'my-new-public-bucket'
   await storage.createBucket(newPublicBucketName, { public: true })
   const res = await storage.getBucket(newPublicBucketName)
-  expect(res.data).toMatchSnapshot()
+  expect(res.data.public).toBe(true)
 })
 
 test('empty bucket', async () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adding a public option when creating and updating a bucket.

Related to https://github.com/supabase/storage-js/issues/11

## What is the current behavior?

There is no method for creating a public bucket. 

## What is the new behavior?

Users can create public bucket by calling `await storage.createBucket(newPublicBucketName, { public: true })`
