### PR TITLE
fix: return the full URL in both places

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "types-generate": "dts-gen -m '@supabase/storage-js' -s",
     "test": "run-s test:clean test:infra test:suite test:clean",
     "test:suite": "jest --runInBand",
-    "test:infra": "cd infra && docker-compose down && docker-compose up -d && sleep 3",
+    "test:infra": "cd infra && docker-compose down && docker-compose up -d && sleep 6",
     "test:clean": "cd infra && docker-compose down --remove-orphans",
     "docs": "typedoc --mode file --target ES6 --theme minimal",
     "docs:json": "typedoc --json docs/spec.json --mode modules --includeDeclarations --excludeExternals"

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -192,9 +192,8 @@ export class StorageFileApi {
   } {
     try {
       const _path = this._getFinalPath(path)
-      let publicURL = `/object/public/${_path}`
+      const publicURL = `${this.url}/object/public/${_path}`
       const data = { publicURL }
-      publicURL = `${this.url}${publicURL}`
       return { data, error: null, publicURL }
     } catch (error) {
       return { data: null, error, publicURL: null }

--- a/test/__snapshots__/storageFileApi.test.ts.snap
+++ b/test/__snapshots__/storageFileApi.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`get public URL 1`] = `
 Object {
-  "publicURL": "/object/public/my-new-public-bucket/profiles/myUniqueUserId/profile.png",
+  "publicURL": "http://localhost:8000/storage/v1/object/public/my-new-public-bucket/profiles/myUniqueUserId/profile.png",
 }
 `;
 


### PR DESCRIPTION
keeps it consistent wth createSignedURL since that returns an absolute URL. 

We were returning the relative URL in `data.publicURL` and absolute URL in `publicURL`. We should keep both of these the same