### PR TITLE
ptch: add upsert flag in file options for upload

### DIFF
--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -13,6 +13,7 @@ const DEFAULT_SEARCH_OPTIONS = {
 
 const DEFAULT_FILE_OPTIONS: FileOptions = {
   cacheControl: '3600',
+  upsert: false,
 }
 
 export class StorageFileApi {
@@ -51,7 +52,10 @@ export class StorageFileApi {
       const res = await fetch(`${this.url}/object/${_path}`, {
         method: 'POST',
         body: formData,
-        headers: { ...this.headers },
+        headers: {
+          ...this.headers,
+          'x-upsert': String(fileOptions?.upsert),
+        },
       })
 
       if (res.ok) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -26,6 +26,7 @@ export interface SortBy {
 
 export interface FileOptions {
   cacheControl: string
+  upsert?: boolean
 }
 
 export interface SearchOptions {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

Closes #7 

## What is the current behavior?

Currently there is no option overwrite an object on upload.

## What is the new behavior?

Introduces an `upsert` flag with default value false, which sends `x-upsert` in headers to storage api.

