### PR TITLE
Prevent empty results when selecting folder(s) in one bucket that match an object name in another bucket

### DIFF
--- a/infra/postgres/storage-schema.sql
+++ b/infra/postgres/storage-schema.sql
@@ -85,24 +85,20 @@ CREATE OR REPLACE FUNCTION storage.search(prefix text, bucketname text, limits i
   )
  LANGUAGE plpgsql
 AS $function$
-DECLARE
-_bucketId text;
 BEGIN
-    select buckets."id" from buckets where buckets.name=bucketname limit 1 into _bucketId;
 	return query 
 		with files_folders as (
 			select ((string_to_array(objects.name, '/'))[levels]) as folder
 			from objects
 			where objects.name ilike prefix || '%'
-			and bucket_id = _bucketId
+			and bucket_id = bucketname
 			GROUP by folder
 			limit limits
 			offset offsets
 		) 
 		select files_folders.folder as name, objects.id, objects.updated_at, objects.created_at, objects.last_accessed_at, objects.metadata from files_folders 
 		left join objects
-		on prefix || files_folders.folder = objects.name
-        where objects.id is null or objects.bucket_id=_bucketId;
+		on prefix || files_folders.folder = objects.name and objects.bucket_id=bucketname;
 END
 $function$;
 


### PR DESCRIPTION
Given a bucket "a"  and an object name "123/456", and a bucket "b" and an object/folder name "123", when selecting bucketname="a" and prefix="":

Before the fix:
If the latter doesn't exist, a row with only name="123" populated and the other columns being NULL is returned.
If the latter exists, name="123" is left joined with the row with object/folder name "123", and then filtered out by the `WHERE ... objects.bucket_id=bucketname` clause.

After the fix:
The row with object/folder name "123" isn't left joined, so a row with only name="123" populated and the other columns being NULL is returned correctly.