### PR TITLE
feat: allow providing custom fetch implementation

### DIFF
--- a/src/SupabaseStorageClient.ts
+++ b/src/SupabaseStorageClient.ts
@@ -1,8 +1,9 @@
 import { StorageBucketApi, StorageFileApi } from './lib'
+import { Fetch } from './lib/fetch'
 
 export class SupabaseStorageClient extends StorageBucketApi {
-  constructor(url: string, headers: { [key: string]: string } = {}) {
-    super(url, headers)
+  constructor(url: string, headers: { [key: string]: string } = {}, fetch?: Fetch) {
+    super(url, headers, fetch)
   }
 
   /**
@@ -11,6 +12,6 @@ export class SupabaseStorageClient extends StorageBucketApi {
    * @param id The bucket id to operate on.
    */
   from(id: string): StorageFileApi {
-    return new StorageFileApi(this.url, this.headers, id)
+    return new StorageFileApi(this.url, this.headers, id, this.fetch)
   }
 }

--- a/src/lib/StorageBucketApi.ts
+++ b/src/lib/StorageBucketApi.ts
@@ -1,14 +1,16 @@
-import { get, post, put, remove } from './fetch'
+import { Fetch, get, post, put, remove } from './fetch'
 import { Bucket } from './types'
 import { DEFAULT_HEADERS } from './constants'
 
 export class StorageBucketApi {
   protected url: string
   protected headers: { [key: string]: string }
+  protected fetch?: Fetch
 
-  constructor(url: string, headers: { [key: string]: string } = {}) {
+  constructor(url: string, headers: { [key: string]: string } = {}, fetch?: Fetch) {
     this.url = url
     this.headers = { ...DEFAULT_HEADERS, ...headers }
+    this.fetch = fetch
   }
 
   /**
@@ -16,7 +18,7 @@ export class StorageBucketApi {
    */
   async listBuckets(): Promise<{ data: Bucket[] | null; error: Error | null }> {
     try {
-      const data = await get(`${this.url}/bucket`, { headers: this.headers })
+      const data = await get(this.fetch, `${this.url}/bucket`, { headers: this.headers })
       return { data, error: null }
     } catch (error) {
       return { data: null, error }
@@ -30,7 +32,7 @@ export class StorageBucketApi {
    */
   async getBucket(id: string): Promise<{ data: Bucket | null; error: Error | null }> {
     try {
-      const data = await get(`${this.url}/bucket/${id}`, { headers: this.headers })
+      const data = await get(this.fetch, `${this.url}/bucket/${id}`, { headers: this.headers })
       return { data, error: null }
     } catch (error) {
       return { data: null, error }
@@ -49,6 +51,7 @@ export class StorageBucketApi {
   ): Promise<{ data: string | null; error: Error | null }> {
     try {
       const data = await post(
+        this.fetch,
         `${this.url}/bucket`,
         { id, name: id, public: options.public },
         { headers: this.headers }
@@ -70,6 +73,7 @@ export class StorageBucketApi {
   ): Promise<{ data: { message: string } | null; error: Error | null }> {
     try {
       const data = await put(
+        this.fetch,
         `${this.url}/bucket/${id}`,
         { id, name: id, public: options.public },
         { headers: this.headers }
@@ -89,7 +93,12 @@ export class StorageBucketApi {
     id: string
   ): Promise<{ data: { message: string } | null; error: Error | null }> {
     try {
-      const data = await post(`${this.url}/bucket/${id}/empty`, {}, { headers: this.headers })
+      const data = await post(
+        this.fetch,
+        `${this.url}/bucket/${id}/empty`,
+        {},
+        { headers: this.headers }
+      )
       return { data, error: null }
     } catch (error) {
       return { data: null, error }
@@ -106,7 +115,12 @@ export class StorageBucketApi {
     id: string
   ): Promise<{ data: { message: string } | null; error: Error | null }> {
     try {
-      const data = await remove(`${this.url}/bucket/${id}`, {}, { headers: this.headers })
+      const data = await remove(
+        this.fetch,
+        `${this.url}/bucket/${id}`,
+        {},
+        { headers: this.headers }
+      )
       return { data, error: null }
     } catch (error) {
       return { data: null, error }

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,4 +1,6 @@
-import fetch from 'cross-fetch'
+import crossFetch from 'cross-fetch'
+
+export type Fetch = typeof fetch
 
 export interface FetchOptions {
   headers?: {
@@ -46,6 +48,7 @@ const _getRequestParams = (
 }
 
 async function _handleRequest(
+  fetcher: Fetch = crossFetch,
   method: RequestMethodType,
   url: string,
   options?: FetchOptions,
@@ -53,7 +56,7 @@ async function _handleRequest(
   body?: object
 ): Promise<any> {
   return new Promise((resolve, reject) => {
-    fetch(url, _getRequestParams(method, options, parameters, body))
+    fetcher(url, _getRequestParams(method, options, parameters, body))
       .then((result) => {
         if (!result.ok) throw result
         if (options?.noResolveJson) return resolve(result)
@@ -65,36 +68,40 @@ async function _handleRequest(
 }
 
 export async function get(
+  fetcher: Fetch | undefined,
   url: string,
   options?: FetchOptions,
   parameters?: FetchParameters
 ): Promise<any> {
-  return _handleRequest('GET', url, options, parameters)
+  return _handleRequest(fetcher, 'GET', url, options, parameters)
 }
 
 export async function post(
+  fetcher: Fetch | undefined,
   url: string,
   body: object,
   options?: FetchOptions,
   parameters?: FetchParameters
 ): Promise<any> {
-  return _handleRequest('POST', url, options, parameters, body)
+  return _handleRequest(fetcher, 'POST', url, options, parameters, body)
 }
 
 export async function put(
+  fetcher: Fetch | undefined,
   url: string,
   body: object,
   options?: FetchOptions,
   parameters?: FetchParameters
 ): Promise<any> {
-  return _handleRequest('PUT', url, options, parameters, body)
+  return _handleRequest(fetcher, 'PUT', url, options, parameters, body)
 }
 
 export async function remove(
+  fetcher: Fetch | undefined,
   url: string,
   body: object,
   options?: FetchOptions,
   parameters?: FetchParameters
 ): Promise<any> {
-  return _handleRequest('DELETE', url, options, parameters, body)
+  return _handleRequest(fetcher, 'DELETE', url, options, parameters, body)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds the ability to provide a custom `fetch` implementation as an option - this is most useful for environments where `cross-fetch` is not supported, for instance Cloudflare Workers or Vercel Edge Functions.

This is related to https://github.com/supabase/supabase-js/issues/154, and I believe a similar option would need to be added to the other libraries using `cross-fetch` before being finally added to `supabase-js`.

## What is the current behavior?

At the moment, `cross-fetch` is always used in all environments.

## What is the new behavior?

There is a new option `fetch` that can be provided to override `cross-fetch` with an alternative library (or the native `fetch`):

```js
import { SupabaseStorageClient } from '@supabase/storage-js'

const url = '...'
const headers = {}
const fetch = ...

const storage = new SupabaseStorageClient(url, headers, fetch)
```

## Additional context

Wrapped library PRs:

- https://github.com/supabase/storage-js/pull/24 (this PR)
- https://github.com/supabase/postgrest-js/pull/222
- https://github.com/supabase/gotrue-js/pull/168

`supabase-js` PR:

- https://github.com/supabase/supabase-js/pull/297