### PR TITLE
fix/empty-name-folder: Removes leading / or "//" anywhere else in new path

### DIFF
--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -333,6 +333,6 @@ export class StorageFileApi {
   }
 
   _removeEmptyFolders(path: string) {
-    return path.replace(/^\/|\/$/g, '\1').replace(/\/\//g, '/')
+    return path.replace(/^\/|\/$/g, '').replace(/\/+/g, '/')
   }
 }

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -84,7 +84,8 @@ export class StorageFileApi {
         headers['content-type'] = options.contentType as string
       }
 
-      const _path = this._getFinalPath(path)
+      const cleanPath = this._removeEmptyFolders(path)
+      const _path = this._getFinalPath(cleanPath)
       const res = await fetch(`${this.url}/object/${_path}`, {
         method,
         body: body as BodyInit,
@@ -237,9 +238,7 @@ export class StorageFileApi {
    *
    * @param path The file path to be downloaded, including the path and file name. For example `folder/image.png`.
    */
-  getPublicUrl(
-    path: string
-  ): {
+  getPublicUrl(path: string): {
     data: { publicURL: string } | null
     error: Error | null
     publicURL: string | null
@@ -331,5 +330,9 @@ export class StorageFileApi {
 
   _getFinalPath(path: string) {
     return `${this.bucketId}/${path}`
+  }
+
+  _removeEmptyFolders(path: string) {
+    return path.replace(/^\/|\/$/g, '\1').replace(/\/\//g, '/')
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix - addresses [#4633](https://github.com/supabase/supabase/issues/4633)

## What is the current behavior?

Calling 
```Javascript 
storage.from(bucketName).upload('/file-name.ext', aFile)
``` 

or 
```Javascript
storage.from(bucketName).upload('folder//file-name.ext', aFile)
``` 

creates a folder with no name. This new nameless folder cannot be deleted. 

## What is the new behavior?

Cleans up upload path by removing any leading `/` or `//` anywhere in the path

## Additional context

Alternatively, this could be a regex test that throws an error when `//` or leading `/` is detected
