### PR TITLE
Feat: Copy object

### DIFF
--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -162,10 +162,10 @@ export class StorageFileApi {
   }
 
   /**
-   * Moves an existing file, optionally renaming it at the same time.
+   * Moves an existing file.
    *
    * @param fromPath The original file path, including the current file name. For example `folder/image.png`.
-   * @param toPath The new file path, including the new file name. For example `folder/image-copy.png`.
+   * @param toPath The new file path, including the new file name. For example `folder/image-new.png`.
    */
   async move(
     fromPath: string,
@@ -261,7 +261,9 @@ export class StorageFileApi {
    *
    * @param path The file path to be downloaded, including the path and file name. For example `folder/image.png`.
    */
-  getPublicUrl(path: string): {
+  getPublicUrl(
+    path: string
+  ): {
     data: { publicURL: string } | null
     error: Error | null
     publicURL: string | null

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -185,6 +185,29 @@ export class StorageFileApi {
   }
 
   /**
+   * Copies an existing file.
+   *
+   * @param fromPath The original file path, including the current file name. For example `folder/image.png`.
+   * @param toPath The new file path, including the new file name. For example `folder/image-copy.png`.
+   */
+  async copy(
+    fromPath: string,
+    toPath: string
+  ): Promise<{ data: { message: string } | null; error: Error | null }> {
+    try {
+      const data = await post(
+        this.fetch,
+        `${this.url}/object/copy`,
+        { bucketId: this.bucketId, sourceKey: fromPath, destinationKey: toPath },
+        { headers: this.headers }
+      )
+      return { data, error: null }
+    } catch (error) {
+      return { data: null, error }
+    }
+  }
+
+  /**
    * Create signed url to download file without requiring permissions. This URL can be valid for a set number of seconds.
    *
    * @param path The file path to be downloaded, including the current file name. For example `folder/image.png`.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Makes the "copy" API available in the client as described in this issue: https://github.com/supabase/storage-js/issues/29 (I believe this issue is incorrectly marked as closed.)

## What is the current behavior?

n/a

## What is the new behavior?

I works just like the `move()` method, but hits up the `/object/copy` endpoint instead.

## Additional context

n/a
