### PR TITLE
feat: add search param to list function

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,6 +39,9 @@ export interface SearchOptions {
 
   /** The column to sort by. Can be any column inside a FileObject. */
   sortBy?: SortBy
+
+  /** The search string to filter files by. */
+  search?: string
 }
 
 // TODO: need to check for metadata props. The api swagger doesnt have.


### PR DESCRIPTION
A simple non-breaking change that adds the new search param (added in https://github.com/supabase/storage-api/pull/127) to the list function.