### PR TITLE
feat: improve function return types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "cross-fetch": "^3.1.0"
+        "cross-fetch": "^3.1.5"
       },
       "devDependencies": {
         "@types/jest": "^26.0.13",
@@ -24,7 +24,7 @@
         "ts-jest": "^26.3.0",
         "ts-loader": "^8.0.11",
         "typedoc": "^0.19.1",
-        "typescript": "^4.0.2",
+        "typescript": "^4.6.3",
         "webpack": "^5.4.0",
         "webpack-cli": "^4.2.0"
       }
@@ -2076,11 +2076,11 @@
       "peer": true
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
-      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "dependencies": {
-        "node-fetch": "2.6.1"
+        "node-fetch": "2.6.7"
       }
     },
     "node_modules/cross-spawn": {
@@ -5000,11 +5000,41 @@
       "dev": true
     },
     "node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-int64": {
@@ -7790,9 +7820,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.7.tgz",
-      "integrity": "sha512-yi7M4y74SWvYbnazbn8/bmJmX4Zlej39ZOqwG/8dut/MYoSQ119GY9ZFbbGsD4PFZYWxqik/XsP3vk3+W5H3og==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -10244,11 +10274,11 @@
       "peer": true
     },
     "cross-fetch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
-      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "requires": {
-        "node-fetch": "2.6.1"
+        "node-fetch": "2.6.7"
       }
     },
     "cross-spawn": {
@@ -12478,9 +12508,33 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -14628,9 +14682,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.7.tgz",
-      "integrity": "sha512-yi7M4y74SWvYbnazbn8/bmJmX4Zlej39ZOqwG/8dut/MYoSQ119GY9ZFbbGsD4PFZYWxqik/XsP3vk3+W5H3og==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "docs:json": "typedoc --json docs/spec.json --mode modules --includeDeclarations --excludeExternals"
   },
   "dependencies": {
-    "cross-fetch": "^3.1.0"
+    "cross-fetch": "^3.1.5"
   },
   "devDependencies": {
     "@types/jest": "^26.0.13",
@@ -51,7 +51,7 @@
     "ts-jest": "^26.3.0",
     "ts-loader": "^8.0.11",
     "typedoc": "^0.19.1",
-    "typescript": "^4.0.2",
+    "typescript": "^4.6.3",
     "webpack": "^5.4.0",
     "webpack-cli": "^4.2.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export {
   StorageClient as SupabaseStorageClient,
 } from './StorageClient'
 export * from './lib/types'
+export * from './lib/errors'

--- a/src/lib/StorageBucketApi.ts
+++ b/src/lib/StorageBucketApi.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_HEADERS } from './constants'
-import { StorageError } from './errors'
+import { isStorageError, StorageError } from './errors'
 import { Fetch, get, post, put, remove } from './fetch'
 import { resolveFetch } from './helpers'
 import { Bucket } from './types'
@@ -32,7 +32,7 @@ export class StorageBucketApi {
       const data = await get(this.fetch, `${this.url}/bucket`, { headers: this.headers })
       return { data, error: null }
     } catch (error) {
-      if (StorageError.isStorageError(error)) {
+      if (isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -61,7 +61,7 @@ export class StorageBucketApi {
       const data = await get(this.fetch, `${this.url}/bucket/${id}`, { headers: this.headers })
       return { data, error: null }
     } catch (error) {
-      if (StorageError.isStorageError(error)) {
+      if (isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -97,7 +97,7 @@ export class StorageBucketApi {
       )
       return { data: data.name, error: null }
     } catch (error) {
-      if (StorageError.isStorageError(error)) {
+      if (isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -132,7 +132,7 @@ export class StorageBucketApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (StorageError.isStorageError(error)) {
+      if (isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -166,7 +166,7 @@ export class StorageBucketApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (StorageError.isStorageError(error)) {
+      if (isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -201,7 +201,7 @@ export class StorageBucketApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (StorageError.isStorageError(error)) {
+      if (isStorageError(error)) {
         return { data: null, error }
       }
 

--- a/src/lib/StorageBucketApi.ts
+++ b/src/lib/StorageBucketApi.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_HEADERS } from './constants'
-import { StorageApiError } from './errors'
+import { StorageError } from './errors'
 import { Fetch, get, post, put, remove } from './fetch'
 import { resolveFetch } from './helpers'
 import { Bucket } from './types'
@@ -25,14 +25,14 @@ export class StorageBucketApi {
       }
     | {
         data: null
-        error: StorageApiError
+        error: StorageError
       }
   > {
     try {
       const data = await get(this.fetch, `${this.url}/bucket`, { headers: this.headers })
       return { data, error: null }
     } catch (error) {
-      if (error instanceof StorageApiError) {
+      if (error instanceof StorageError) {
         return { data: null, error }
       }
 
@@ -54,14 +54,14 @@ export class StorageBucketApi {
       }
     | {
         data: null
-        error: StorageApiError
+        error: StorageError
       }
   > {
     try {
       const data = await get(this.fetch, `${this.url}/bucket/${id}`, { headers: this.headers })
       return { data, error: null }
     } catch (error) {
-      if (error instanceof StorageApiError) {
+      if (error instanceof StorageError) {
         return { data: null, error }
       }
 
@@ -85,7 +85,7 @@ export class StorageBucketApi {
       }
     | {
         data: null
-        error: StorageApiError
+        error: StorageError
       }
   > {
     try {
@@ -97,7 +97,7 @@ export class StorageBucketApi {
       )
       return { data: data.name, error: null }
     } catch (error) {
-      if (error instanceof StorageApiError) {
+      if (error instanceof StorageError) {
         return { data: null, error }
       }
 
@@ -120,7 +120,7 @@ export class StorageBucketApi {
       }
     | {
         data: null
-        error: StorageApiError
+        error: StorageError
       }
   > {
     try {
@@ -132,7 +132,7 @@ export class StorageBucketApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (error instanceof StorageApiError) {
+      if (error instanceof StorageError) {
         return { data: null, error }
       }
 
@@ -154,7 +154,7 @@ export class StorageBucketApi {
       }
     | {
         data: null
-        error: StorageApiError
+        error: StorageError
       }
   > {
     try {
@@ -166,7 +166,7 @@ export class StorageBucketApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (error instanceof StorageApiError) {
+      if (error instanceof StorageError) {
         return { data: null, error }
       }
 
@@ -189,7 +189,7 @@ export class StorageBucketApi {
       }
     | {
         data: null
-        error: StorageApiError
+        error: StorageError
       }
   > {
     try {
@@ -201,7 +201,7 @@ export class StorageBucketApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (error instanceof StorageApiError) {
+      if (error instanceof StorageError) {
         return { data: null, error }
       }
 

--- a/src/lib/StorageBucketApi.ts
+++ b/src/lib/StorageBucketApi.ts
@@ -17,7 +17,16 @@ export class StorageBucketApi {
   /**
    * Retrieves the details of all Storage buckets within an existing product.
    */
-  async listBuckets(): Promise<{ data: Bucket[] | null; error: Error | null }> {
+  async listBuckets(): Promise<
+    | {
+        data: Bucket[]
+        error: null
+      }
+    | {
+        data: null
+        error: unknown
+      }
+  > {
     try {
       const data = await get(this.fetch, `${this.url}/bucket`, { headers: this.headers })
       return { data, error: null }
@@ -31,7 +40,18 @@ export class StorageBucketApi {
    *
    * @param id The unique identifier of the bucket you would like to retrieve.
    */
-  async getBucket(id: string): Promise<{ data: Bucket | null; error: Error | null }> {
+  async getBucket(
+    id: string
+  ): Promise<
+    | {
+        data: Bucket
+        error: null
+      }
+    | {
+        data: null
+        error: unknown
+      }
+  > {
     try {
       const data = await get(this.fetch, `${this.url}/bucket/${id}`, { headers: this.headers })
       return { data, error: null }
@@ -49,7 +69,16 @@ export class StorageBucketApi {
   async createBucket(
     id: string,
     options: { public: boolean } = { public: false }
-  ): Promise<{ data: string | null; error: Error | null }> {
+  ): Promise<
+    | {
+        data: string
+        error: null
+      }
+    | {
+        data: null
+        error: unknown
+      }
+  > {
     try {
       const data = await post(
         this.fetch,
@@ -71,7 +100,16 @@ export class StorageBucketApi {
   async updateBucket(
     id: string,
     options: { public: boolean }
-  ): Promise<{ data: { message: string } | null; error: Error | null }> {
+  ): Promise<
+    | {
+        data: { message: string }
+        error: null
+      }
+    | {
+        data: null
+        error: unknown
+      }
+  > {
     try {
       const data = await put(
         this.fetch,
@@ -92,7 +130,16 @@ export class StorageBucketApi {
    */
   async emptyBucket(
     id: string
-  ): Promise<{ data: { message: string } | null; error: Error | null }> {
+  ): Promise<
+    | {
+        data: { message: string }
+        error: null
+      }
+    | {
+        data: null
+        error: unknown
+      }
+  > {
     try {
       const data = await post(
         this.fetch,
@@ -114,7 +161,16 @@ export class StorageBucketApi {
    */
   async deleteBucket(
     id: string
-  ): Promise<{ data: { message: string } | null; error: Error | null }> {
+  ): Promise<
+    | {
+        data: { message: string }
+        error: null
+      }
+    | {
+        data: null
+        error: unknown
+      }
+  > {
     try {
       const data = await remove(
         this.fetch,

--- a/src/lib/StorageBucketApi.ts
+++ b/src/lib/StorageBucketApi.ts
@@ -24,14 +24,18 @@ export class StorageBucketApi {
       }
     | {
         data: null
-        error: unknown
+        error: Error
       }
   > {
     try {
       const data = await get(this.fetch, `${this.url}/bucket`, { headers: this.headers })
       return { data, error: null }
     } catch (error) {
-      return { data: null, error }
+      if (error instanceof Error) {
+        return { data: null, error }
+      }
+
+      throw error
     }
   }
 
@@ -49,14 +53,18 @@ export class StorageBucketApi {
       }
     | {
         data: null
-        error: unknown
+        error: Error
       }
   > {
     try {
       const data = await get(this.fetch, `${this.url}/bucket/${id}`, { headers: this.headers })
       return { data, error: null }
     } catch (error) {
-      return { data: null, error }
+      if (error instanceof Error) {
+        return { data: null, error }
+      }
+
+      throw error
     }
   }
 
@@ -76,7 +84,7 @@ export class StorageBucketApi {
       }
     | {
         data: null
-        error: unknown
+        error: Error
       }
   > {
     try {
@@ -88,7 +96,11 @@ export class StorageBucketApi {
       )
       return { data: data.name, error: null }
     } catch (error) {
-      return { data: null, error }
+      if (error instanceof Error) {
+        return { data: null, error }
+      }
+
+      throw error
     }
   }
 
@@ -107,7 +119,7 @@ export class StorageBucketApi {
       }
     | {
         data: null
-        error: unknown
+        error: Error
       }
   > {
     try {
@@ -119,7 +131,11 @@ export class StorageBucketApi {
       )
       return { data, error: null }
     } catch (error) {
-      return { data: null, error }
+      if (error instanceof Error) {
+        return { data: null, error }
+      }
+
+      throw error
     }
   }
 
@@ -137,7 +153,7 @@ export class StorageBucketApi {
       }
     | {
         data: null
-        error: unknown
+        error: Error
       }
   > {
     try {
@@ -149,7 +165,11 @@ export class StorageBucketApi {
       )
       return { data, error: null }
     } catch (error) {
-      return { data: null, error }
+      if (error instanceof Error) {
+        return { data: null, error }
+      }
+
+      throw error
     }
   }
 
@@ -168,7 +188,7 @@ export class StorageBucketApi {
       }
     | {
         data: null
-        error: unknown
+        error: Error
       }
   > {
     try {
@@ -180,7 +200,11 @@ export class StorageBucketApi {
       )
       return { data, error: null }
     } catch (error) {
-      return { data: null, error }
+      if (error instanceof Error) {
+        return { data: null, error }
+      }
+
+      throw error
     }
   }
 }

--- a/src/lib/StorageBucketApi.ts
+++ b/src/lib/StorageBucketApi.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_HEADERS } from './constants'
+import { StorageApiError } from './errors'
 import { Fetch, get, post, put, remove } from './fetch'
 import { resolveFetch } from './helpers'
 import { Bucket } from './types'
@@ -24,14 +25,14 @@ export class StorageBucketApi {
       }
     | {
         data: null
-        error: Error
+        error: StorageApiError
       }
   > {
     try {
       const data = await get(this.fetch, `${this.url}/bucket`, { headers: this.headers })
       return { data, error: null }
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof StorageApiError) {
         return { data: null, error }
       }
 
@@ -53,14 +54,14 @@ export class StorageBucketApi {
       }
     | {
         data: null
-        error: Error
+        error: StorageApiError
       }
   > {
     try {
       const data = await get(this.fetch, `${this.url}/bucket/${id}`, { headers: this.headers })
       return { data, error: null }
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof StorageApiError) {
         return { data: null, error }
       }
 
@@ -84,7 +85,7 @@ export class StorageBucketApi {
       }
     | {
         data: null
-        error: Error
+        error: StorageApiError
       }
   > {
     try {
@@ -96,7 +97,7 @@ export class StorageBucketApi {
       )
       return { data: data.name, error: null }
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof StorageApiError) {
         return { data: null, error }
       }
 
@@ -119,7 +120,7 @@ export class StorageBucketApi {
       }
     | {
         data: null
-        error: Error
+        error: StorageApiError
       }
   > {
     try {
@@ -131,7 +132,7 @@ export class StorageBucketApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof StorageApiError) {
         return { data: null, error }
       }
 
@@ -153,7 +154,7 @@ export class StorageBucketApi {
       }
     | {
         data: null
-        error: Error
+        error: StorageApiError
       }
   > {
     try {
@@ -165,7 +166,7 @@ export class StorageBucketApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof StorageApiError) {
         return { data: null, error }
       }
 
@@ -188,7 +189,7 @@ export class StorageBucketApi {
       }
     | {
         data: null
-        error: Error
+        error: StorageApiError
       }
   > {
     try {
@@ -200,7 +201,7 @@ export class StorageBucketApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof StorageApiError) {
         return { data: null, error }
       }
 

--- a/src/lib/StorageBucketApi.ts
+++ b/src/lib/StorageBucketApi.ts
@@ -32,7 +32,7 @@ export class StorageBucketApi {
       const data = await get(this.fetch, `${this.url}/bucket`, { headers: this.headers })
       return { data, error: null }
     } catch (error) {
-      if (error instanceof StorageError) {
+      if (StorageError.isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -61,7 +61,7 @@ export class StorageBucketApi {
       const data = await get(this.fetch, `${this.url}/bucket/${id}`, { headers: this.headers })
       return { data, error: null }
     } catch (error) {
-      if (error instanceof StorageError) {
+      if (StorageError.isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -97,7 +97,7 @@ export class StorageBucketApi {
       )
       return { data: data.name, error: null }
     } catch (error) {
-      if (error instanceof StorageError) {
+      if (StorageError.isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -132,7 +132,7 @@ export class StorageBucketApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (error instanceof StorageError) {
+      if (StorageError.isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -166,7 +166,7 @@ export class StorageBucketApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (error instanceof StorageError) {
+      if (StorageError.isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -201,7 +201,7 @@ export class StorageBucketApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (error instanceof StorageError) {
+      if (StorageError.isStorageError(error)) {
         return { data: null, error }
       }
 

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -1,4 +1,4 @@
-import { StorageError } from './errors'
+import { isStorageError, StorageError } from './errors'
 import { Fetch, FetchParameters, get, post, remove } from './fetch'
 import { resolveFetch } from './helpers'
 import { FileObject, FileOptions, SearchOptions } from './types'
@@ -112,7 +112,7 @@ export class StorageFileApi {
         return { data: null, error }
       }
     } catch (error) {
-      if (StorageError.isStorageError(error)) {
+      if (isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -226,7 +226,7 @@ export class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (StorageError.isStorageError(error)) {
+      if (isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -262,7 +262,7 @@ export class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (StorageError.isStorageError(error)) {
+      if (isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -303,7 +303,7 @@ export class StorageFileApi {
       data = { signedURL }
       return { data, error: null, signedURL }
     } catch (error) {
-      if (StorageError.isStorageError(error)) {
+      if (isStorageError(error)) {
         return { data: null, error, signedURL: null }
       }
 
@@ -345,7 +345,7 @@ export class StorageFileApi {
         error: null,
       }
     } catch (error) {
-      if (StorageError.isStorageError(error)) {
+      if (isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -379,7 +379,7 @@ export class StorageFileApi {
       const data = await res.blob()
       return { data, error: null }
     } catch (error) {
-      if (StorageError.isStorageError(error)) {
+      if (isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -413,7 +413,7 @@ export class StorageFileApi {
       const data = { publicURL }
       return { data, error: null, publicURL }
     } catch (error) {
-      if (StorageError.isStorageError(error)) {
+      if (isStorageError(error)) {
         return { data: null, error, publicURL: null }
       }
 
@@ -447,7 +447,7 @@ export class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (StorageError.isStorageError(error)) {
+      if (isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -475,7 +475,7 @@ export class StorageFileApi {
   //     const data = await get(this.fetch, `${this.url}/metadata/${id}`, { headers: this.headers })
   //     return { data, error: null }
   //   } catch (error) {
-  //     if (StorageError.isStorageError(error)) {
+  //     if (isStorageError(error)) {
   //       return { data: null, error }
   //     }
 
@@ -510,7 +510,7 @@ export class StorageFileApi {
   //     )
   //     return { data, error: null }
   //   } catch (error) {
-  //     if (StorageError.isStorageError(error)) {
+  //     if (isStorageError(error)) {
   //       return { data: null, error }
   //     }
 
@@ -549,7 +549,7 @@ export class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (StorageError.isStorageError(error)) {
+      if (isStorageError(error)) {
         return { data: null, error }
       }
 

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -1,3 +1,4 @@
+import { StorageApiError } from './errors'
 import { Fetch, FetchParameters, get, post, remove } from './fetch'
 import { resolveFetch } from './helpers'
 import { FileObject, FileOptions, SearchOptions } from './types'
@@ -70,7 +71,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: Error
+        error: StorageApiError
       }
   > {
     try {
@@ -111,7 +112,7 @@ export class StorageFileApi {
         return { data: null, error }
       }
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof StorageApiError) {
         return { data: null, error }
       }
 
@@ -152,7 +153,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: Error
+        error: StorageApiError
       }
   > {
     return this.uploadOrUpdate('POST', path, fileBody, fileOptions)
@@ -191,7 +192,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: Error
+        error: StorageApiError
       }
   > {
     return this.uploadOrUpdate('PUT', path, fileBody, fileOptions)
@@ -213,7 +214,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: Error
+        error: StorageApiError
       }
   > {
     try {
@@ -225,7 +226,7 @@ export class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof StorageApiError) {
         return { data: null, error }
       }
 
@@ -249,7 +250,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: Error
+        error: StorageApiError
       }
   > {
     try {
@@ -261,7 +262,7 @@ export class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof StorageApiError) {
         return { data: null, error }
       }
 
@@ -286,7 +287,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: Error
+        error: StorageApiError
         signedURL: null
       }
   > {
@@ -302,7 +303,7 @@ export class StorageFileApi {
       data = { signedURL }
       return { data, error: null, signedURL }
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof StorageApiError) {
         return { data: null, error, signedURL: null }
       }
 
@@ -326,7 +327,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: Error
+        error: StorageApiError
       }
   > {
     try {
@@ -344,7 +345,7 @@ export class StorageFileApi {
         error: null,
       }
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof StorageApiError) {
         return { data: null, error }
       }
 
@@ -366,7 +367,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: Error
+        error: StorageApiError
       }
   > {
     try {
@@ -378,7 +379,7 @@ export class StorageFileApi {
       const data = await res.blob()
       return { data, error: null }
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof StorageApiError) {
         return { data: null, error }
       }
 
@@ -403,7 +404,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: Error
+        error: StorageApiError
         publicURL: null
       } {
     try {
@@ -412,7 +413,7 @@ export class StorageFileApi {
       const data = { publicURL }
       return { data, error: null, publicURL }
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof StorageApiError) {
         return { data: null, error, publicURL: null }
       }
 
@@ -434,7 +435,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: Error
+        error: StorageApiError
       }
   > {
     try {
@@ -446,7 +447,7 @@ export class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof StorageApiError) {
         return { data: null, error }
       }
 
@@ -458,7 +459,7 @@ export class StorageFileApi {
    * Get file metadata
    * @param id the file id to retrieve metadata
    */
-  // async getMetadata(id: string): Promise<{ data: Metadata | null; error: Error | null }> {
+  // async getMetadata(id: string): Promise<{ data: Metadata | null; error: StorageApiError | null }> {
   //   try {
   //     const data = await get(`${this.url}/metadata/${id}`, { headers: this.headers })
   //     return { data, error: null }
@@ -475,7 +476,7 @@ export class StorageFileApi {
   // async updateMetadata(
   //   id: string,
   //   meta: Metadata
-  // ): Promise<{ data: Metadata | null; error: Error | null }> {
+  // ): Promise<{ data: Metadata | null; error: StorageApiError | null }> {
   //   try {
   //     const data = await post(`${this.url}/metadata/${id}`, { ...meta }, { headers: this.headers })
   //     return { data, error: null }
@@ -501,7 +502,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: Error
+        error: StorageApiError
       }
   > {
     try {
@@ -515,7 +516,7 @@ export class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof StorageApiError) {
         return { data: null, error }
       }
 

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -61,7 +61,18 @@ export class StorageFileApi {
       | URLSearchParams
       | string,
     fileOptions?: FileOptions
-  ): Promise<{ data: { Key: string } | null; error: Error | null }> {
+  ): Promise<
+    | {
+        data: {
+          Key: string
+        }
+        error: null
+      }
+    | {
+        data: null
+        error: unknown
+      }
+  > {
     try {
       let body
       const options = { ...DEFAULT_FILE_OPTIONS, ...fileOptions }
@@ -128,7 +139,18 @@ export class StorageFileApi {
       | URLSearchParams
       | string,
     fileOptions?: FileOptions
-  ): Promise<{ data: { Key: string } | null; error: Error | null }> {
+  ): Promise<
+    | {
+        data: {
+          Key: string
+        }
+        error: null
+      }
+    | {
+        data: null
+        error: unknown
+      }
+  > {
     return this.uploadOrUpdate('POST', path, fileBody, fileOptions)
   }
 
@@ -156,7 +178,18 @@ export class StorageFileApi {
       | URLSearchParams
       | string,
     fileOptions?: FileOptions
-  ): Promise<{ data: { Key: string } | null; error: Error | null }> {
+  ): Promise<
+    | {
+        data: {
+          Key: string
+        }
+        error: null
+      }
+    | {
+        data: null
+        error: unknown
+      }
+  > {
     return this.uploadOrUpdate('PUT', path, fileBody, fileOptions)
   }
 
@@ -169,7 +202,16 @@ export class StorageFileApi {
   async move(
     fromPath: string,
     toPath: string
-  ): Promise<{ data: { message: string } | null; error: Error | null }> {
+  ): Promise<
+    | {
+        data: { message: string }
+        error: null
+      }
+    | {
+        data: null
+        error: unknown
+      }
+  > {
     try {
       const data = await post(
         this.fetch,
@@ -192,7 +234,16 @@ export class StorageFileApi {
   async copy(
     fromPath: string,
     toPath: string
-  ): Promise<{ data: { message: string } | null; error: Error | null }> {
+  ): Promise<
+    | {
+        data: { message: string }
+        error: null
+      }
+    | {
+        data: null
+        error: unknown
+      }
+  > {
     try {
       const data = await post(
         this.fetch,
@@ -215,11 +266,18 @@ export class StorageFileApi {
   async createSignedUrl(
     path: string,
     expiresIn: number
-  ): Promise<{
-    data: { signedURL: string } | null
-    error: Error | null
-    signedURL: string | null
-  }> {
+  ): Promise<
+    | {
+        data: { signedURL: string }
+        error: null
+        signedURL: string
+      }
+    | {
+        data: null
+        error: unknown
+        signedURL: null
+      }
+  > {
     try {
       const _path = this._getFinalPath(path)
       let data = await post(
@@ -245,10 +303,16 @@ export class StorageFileApi {
   async createSignedUrls(
     paths: string[],
     expiresIn: number
-  ): Promise<{
-    data: { error: string | null; path: string | null; signedURL: string }[] | null
-    error: Error | null
-  }> {
+  ): Promise<
+    | {
+        data: { error: string | null; path: string | null; signedURL: string }[]
+        error: null
+      }
+    | {
+        data: null
+        error: unknown
+      }
+  > {
     try {
       const data = await post(
         this.fetch,
@@ -273,7 +337,18 @@ export class StorageFileApi {
    *
    * @param path The file path to be downloaded, including the path and file name. For example `folder/image.png`.
    */
-  async download(path: string): Promise<{ data: Blob | null; error: Error | null }> {
+  async download(
+    path: string
+  ): Promise<
+    | {
+        data: Blob
+        error: null
+      }
+    | {
+        data: null
+        error: unknown
+      }
+  > {
     try {
       const _path = this._getFinalPath(path)
       const res = await get(this.fetch, `${this.url}/object/${_path}`, {
@@ -294,11 +369,19 @@ export class StorageFileApi {
    */
   getPublicUrl(
     path: string
-  ): {
-    data: { publicURL: string } | null
-    error: Error | null
-    publicURL: string | null
-  } {
+  ):
+    | {
+        data: {
+          publicURL: string
+        }
+        error: null
+        publicURL: string
+      }
+    | {
+        data: null
+        error: unknown
+        publicURL: null
+      } {
     try {
       const _path = this._getFinalPath(path)
       const publicURL = `${this.url}/object/public/${_path}`
@@ -314,7 +397,18 @@ export class StorageFileApi {
    *
    * @param paths An array of files to be deleted, including the path and file name. For example [`folder/image.png`].
    */
-  async remove(paths: string[]): Promise<{ data: FileObject[] | null; error: Error | null }> {
+  async remove(
+    paths: string[]
+  ): Promise<
+    | {
+        data: FileObject[]
+        error: null
+      }
+    | {
+        data: null
+        error: unknown
+      }
+  > {
     try {
       const data = await remove(
         this.fetch,
@@ -368,7 +462,16 @@ export class StorageFileApi {
     path?: string,
     options?: SearchOptions,
     parameters?: FetchParameters
-  ): Promise<{ data: FileObject[] | null; error: Error | null }> {
+  ): Promise<
+    | {
+        data: FileObject[]
+        error: null
+      }
+    | {
+        data: null
+        error: unknown
+      }
+  > {
     try {
       const body = { ...DEFAULT_SEARCH_OPTIONS, ...options, prefix: path || '' }
       const data = await post(

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -112,7 +112,7 @@ export class StorageFileApi {
         return { data: null, error }
       }
     } catch (error) {
-      if (error instanceof StorageError) {
+      if (StorageError.isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -226,7 +226,7 @@ export class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (error instanceof StorageError) {
+      if (StorageError.isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -262,7 +262,7 @@ export class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (error instanceof StorageError) {
+      if (StorageError.isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -303,7 +303,7 @@ export class StorageFileApi {
       data = { signedURL }
       return { data, error: null, signedURL }
     } catch (error) {
-      if (error instanceof StorageError) {
+      if (StorageError.isStorageError(error)) {
         return { data: null, error, signedURL: null }
       }
 
@@ -345,7 +345,7 @@ export class StorageFileApi {
         error: null,
       }
     } catch (error) {
-      if (error instanceof StorageError) {
+      if (StorageError.isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -379,7 +379,7 @@ export class StorageFileApi {
       const data = await res.blob()
       return { data, error: null }
     } catch (error) {
-      if (error instanceof StorageError) {
+      if (StorageError.isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -413,7 +413,7 @@ export class StorageFileApi {
       const data = { publicURL }
       return { data, error: null, publicURL }
     } catch (error) {
-      if (error instanceof StorageError) {
+      if (StorageError.isStorageError(error)) {
         return { data: null, error, publicURL: null }
       }
 
@@ -447,7 +447,7 @@ export class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (error instanceof StorageError) {
+      if (StorageError.isStorageError(error)) {
         return { data: null, error }
       }
 
@@ -475,7 +475,7 @@ export class StorageFileApi {
   //     const data = await get(this.fetch, `${this.url}/metadata/${id}`, { headers: this.headers })
   //     return { data, error: null }
   //   } catch (error) {
-  //     if (error instanceof StorageError) {
+  //     if (StorageError.isStorageError(error)) {
   //       return { data: null, error }
   //     }
 
@@ -510,7 +510,7 @@ export class StorageFileApi {
   //     )
   //     return { data, error: null }
   //   } catch (error) {
-  //     if (error instanceof StorageError) {
+  //     if (StorageError.isStorageError(error)) {
   //       return { data: null, error }
   //     }
 
@@ -549,7 +549,7 @@ export class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (error instanceof StorageError) {
+      if (StorageError.isStorageError(error)) {
         return { data: null, error }
       }
 

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -70,7 +70,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: unknown
+        error: Error
       }
   > {
     try {
@@ -111,7 +111,11 @@ export class StorageFileApi {
         return { data: null, error }
       }
     } catch (error) {
-      return { data: null, error }
+      if (error instanceof Error) {
+        return { data: null, error }
+      }
+
+      throw error
     }
   }
 
@@ -148,7 +152,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: unknown
+        error: Error
       }
   > {
     return this.uploadOrUpdate('POST', path, fileBody, fileOptions)
@@ -187,7 +191,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: unknown
+        error: Error
       }
   > {
     return this.uploadOrUpdate('PUT', path, fileBody, fileOptions)
@@ -209,7 +213,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: unknown
+        error: Error
       }
   > {
     try {
@@ -221,7 +225,11 @@ export class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
-      return { data: null, error }
+      if (error instanceof Error) {
+        return { data: null, error }
+      }
+
+      throw error
     }
   }
 
@@ -241,7 +249,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: unknown
+        error: Error
       }
   > {
     try {
@@ -253,7 +261,11 @@ export class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
-      return { data: null, error }
+      if (error instanceof Error) {
+        return { data: null, error }
+      }
+
+      throw error
     }
   }
 
@@ -274,7 +286,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: unknown
+        error: Error
         signedURL: null
       }
   > {
@@ -290,7 +302,11 @@ export class StorageFileApi {
       data = { signedURL }
       return { data, error: null, signedURL }
     } catch (error) {
-      return { data: null, error, signedURL: null }
+      if (error instanceof Error) {
+        return { data: null, error, signedURL: null }
+      }
+
+      throw error
     }
   }
 
@@ -310,7 +326,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: unknown
+        error: Error
       }
   > {
     try {
@@ -328,7 +344,11 @@ export class StorageFileApi {
         error: null,
       }
     } catch (error) {
-      return { data: null, error }
+      if (error instanceof Error) {
+        return { data: null, error }
+      }
+
+      throw error
     }
   }
 
@@ -346,7 +366,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: unknown
+        error: Error
       }
   > {
     try {
@@ -358,7 +378,11 @@ export class StorageFileApi {
       const data = await res.blob()
       return { data, error: null }
     } catch (error) {
-      return { data: null, error }
+      if (error instanceof Error) {
+        return { data: null, error }
+      }
+
+      throw error
     }
   }
 
@@ -379,7 +403,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: unknown
+        error: Error
         publicURL: null
       } {
     try {
@@ -388,7 +412,11 @@ export class StorageFileApi {
       const data = { publicURL }
       return { data, error: null, publicURL }
     } catch (error) {
-      return { data: null, error, publicURL: null }
+      if (error instanceof Error) {
+        return { data: null, error, publicURL: null }
+      }
+
+      throw error
     }
   }
 
@@ -406,7 +434,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: unknown
+        error: Error
       }
   > {
     try {
@@ -418,7 +446,11 @@ export class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
-      return { data: null, error }
+      if (error instanceof Error) {
+        return { data: null, error }
+      }
+
+      throw error
     }
   }
 
@@ -469,7 +501,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: unknown
+        error: Error
       }
   > {
     try {
@@ -483,7 +515,11 @@ export class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
-      return { data: null, error }
+      if (error instanceof Error) {
+        return { data: null, error }
+      }
+
+      throw error
     }
   }
 

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -1,4 +1,4 @@
-import { StorageApiError } from './errors'
+import { StorageError } from './errors'
 import { Fetch, FetchParameters, get, post, remove } from './fetch'
 import { resolveFetch } from './helpers'
 import { FileObject, FileOptions, SearchOptions } from './types'
@@ -71,7 +71,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: StorageApiError
+        error: StorageError
       }
   > {
     try {
@@ -112,7 +112,7 @@ export class StorageFileApi {
         return { data: null, error }
       }
     } catch (error) {
-      if (error instanceof StorageApiError) {
+      if (error instanceof StorageError) {
         return { data: null, error }
       }
 
@@ -153,7 +153,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: StorageApiError
+        error: StorageError
       }
   > {
     return this.uploadOrUpdate('POST', path, fileBody, fileOptions)
@@ -192,7 +192,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: StorageApiError
+        error: StorageError
       }
   > {
     return this.uploadOrUpdate('PUT', path, fileBody, fileOptions)
@@ -214,7 +214,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: StorageApiError
+        error: StorageError
       }
   > {
     try {
@@ -226,7 +226,7 @@ export class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (error instanceof StorageApiError) {
+      if (error instanceof StorageError) {
         return { data: null, error }
       }
 
@@ -250,7 +250,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: StorageApiError
+        error: StorageError
       }
   > {
     try {
@@ -262,7 +262,7 @@ export class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (error instanceof StorageApiError) {
+      if (error instanceof StorageError) {
         return { data: null, error }
       }
 
@@ -287,7 +287,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: StorageApiError
+        error: StorageError
         signedURL: null
       }
   > {
@@ -303,7 +303,7 @@ export class StorageFileApi {
       data = { signedURL }
       return { data, error: null, signedURL }
     } catch (error) {
-      if (error instanceof StorageApiError) {
+      if (error instanceof StorageError) {
         return { data: null, error, signedURL: null }
       }
 
@@ -327,7 +327,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: StorageApiError
+        error: StorageError
       }
   > {
     try {
@@ -345,7 +345,7 @@ export class StorageFileApi {
         error: null,
       }
     } catch (error) {
-      if (error instanceof StorageApiError) {
+      if (error instanceof StorageError) {
         return { data: null, error }
       }
 
@@ -367,7 +367,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: StorageApiError
+        error: StorageError
       }
   > {
     try {
@@ -379,7 +379,7 @@ export class StorageFileApi {
       const data = await res.blob()
       return { data, error: null }
     } catch (error) {
-      if (error instanceof StorageApiError) {
+      if (error instanceof StorageError) {
         return { data: null, error }
       }
 
@@ -404,7 +404,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: StorageApiError
+        error: StorageError
         publicURL: null
       } {
     try {
@@ -413,7 +413,7 @@ export class StorageFileApi {
       const data = { publicURL }
       return { data, error: null, publicURL }
     } catch (error) {
-      if (error instanceof StorageApiError) {
+      if (error instanceof StorageError) {
         return { data: null, error, publicURL: null }
       }
 
@@ -435,7 +435,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: StorageApiError
+        error: StorageError
       }
   > {
     try {
@@ -447,7 +447,7 @@ export class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (error instanceof StorageApiError) {
+      if (error instanceof StorageError) {
         return { data: null, error }
       }
 
@@ -459,12 +459,27 @@ export class StorageFileApi {
    * Get file metadata
    * @param id the file id to retrieve metadata
    */
-  // async getMetadata(id: string): Promise<{ data: Metadata | null; error: StorageApiError | null }> {
+  // async getMetadata(
+  //   id: string
+  // ): Promise<
+  //   | {
+  //       data: Metadata
+  //       error: null
+  //     }
+  //   | {
+  //       data: null
+  //       error: StorageError
+  //     }
+  // > {
   //   try {
-  //     const data = await get(`${this.url}/metadata/${id}`, { headers: this.headers })
+  //     const data = await get(this.fetch, `${this.url}/metadata/${id}`, { headers: this.headers })
   //     return { data, error: null }
   //   } catch (error) {
-  //     return { data: null, error }
+  //     if (error instanceof StorageError) {
+  //       return { data: null, error }
+  //     }
+
+  //     throw error
   //   }
   // }
 
@@ -476,12 +491,30 @@ export class StorageFileApi {
   // async updateMetadata(
   //   id: string,
   //   meta: Metadata
-  // ): Promise<{ data: Metadata | null; error: StorageApiError | null }> {
+  // ): Promise<
+  //   | {
+  //       data: Metadata
+  //       error: null
+  //     }
+  //   | {
+  //       data: null
+  //       error: StorageError
+  //     }
+  // > {
   //   try {
-  //     const data = await post(`${this.url}/metadata/${id}`, { ...meta }, { headers: this.headers })
+  //     const data = await post(
+  //       this.fetch,
+  //       `${this.url}/metadata/${id}`,
+  //       { ...meta },
+  //       { headers: this.headers }
+  //     )
   //     return { data, error: null }
   //   } catch (error) {
-  //     return { data: null, error }
+  //     if (error instanceof StorageError) {
+  //       return { data: null, error }
+  //     }
+
+  //     throw error
   //   }
   // }
 
@@ -502,7 +535,7 @@ export class StorageFileApi {
       }
     | {
         data: null
-        error: StorageApiError
+        error: StorageError
       }
   > {
     try {
@@ -516,7 +549,7 @@ export class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
-      if (error instanceof StorageApiError) {
+      if (error instanceof StorageError) {
         return { data: null, error }
       }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,16 @@
+export class StorageApiError extends Error {
+  status: number
+
+  constructor(message: string, status: number) {
+    super(message)
+    this.name = 'StorageApiError'
+    this.status = status
+  }
+
+  toJSON() {
+    return {
+      message: this.message,
+      status: this.status,
+    }
+  }
+}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,4 +1,11 @@
-export class StorageApiError extends Error {
+export class StorageError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'StorageError'
+  }
+}
+
+export class StorageApiError extends StorageError {
   status: number
 
   constructor(message: string, status: number) {
@@ -9,8 +16,19 @@ export class StorageApiError extends Error {
 
   toJSON() {
     return {
+      name: this.name,
       message: this.message,
       status: this.status,
     }
+  }
+}
+
+export class StorageUnknownError extends StorageError {
+  originalError: unknown
+
+  constructor(message: string, originalError: unknown) {
+    super(message)
+    this.name = 'StorageUnknownError'
+    this.originalError = originalError
   }
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,4 +1,10 @@
 export class StorageError extends Error {
+  protected __isStorageError = true
+
+  static isStorageError(error: unknown): error is StorageError {
+    return typeof error === 'object' && error !== null && '__isStorageError' in error
+  }
+
   constructor(message: string) {
     super(message)
     this.name = 'StorageError'

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,14 +1,14 @@
 export class StorageError extends Error {
   protected __isStorageError = true
 
-  static isStorageError(error: unknown): error is StorageError {
-    return typeof error === 'object' && error !== null && '__isStorageError' in error
-  }
-
   constructor(message: string) {
     super(message)
     this.name = 'StorageError'
   }
+}
+
+export function isStorageError(error: unknown): error is StorageError {
+  return typeof error === 'object' && error !== null && '__isStorageError' in error
 }
 
 export class StorageApiError extends StorageError {

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,3 +1,5 @@
+import { StorageApiError } from './errors'
+
 export type Fetch = typeof fetch
 
 export interface FetchOptions {
@@ -21,10 +23,7 @@ const handleError = (error: any, reject: any) => {
     return reject(error)
   }
   error.json().then((err: any) => {
-    return reject({
-      message: _getErrorMessage(err),
-      status: error?.status || 500,
-    })
+    return reject(new StorageApiError(_getErrorMessage(err), error?.status || 500))
   })
 }
 
@@ -57,7 +56,7 @@ async function _handleRequest(
     fetcher(url, _getRequestParams(method, options, parameters, body))
       .then((result) => {
         if (!result.ok) throw result
-        if (options?.noResolveJson) return resolve(result)
+        if (options?.noResolveJson) return result
         return result.json()
       })
       .then((data) => resolve(data))

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,4 +1,4 @@
-import crossFetch from 'cross-fetch'
+import crossFetch, { Response as CrossFetchResponse } from 'cross-fetch'
 
 type Fetch = typeof fetch
 
@@ -12,4 +12,12 @@ export const resolveFetch = (customFetch?: Fetch): Fetch => {
     _fetch = fetch
   }
   return (...args) => _fetch(...args)
+}
+
+export const resolveResponse = () => {
+  if (typeof Response === 'undefined') {
+    return CrossFetchResponse
+  }
+
+  return Response
 }

--- a/test/__snapshots__/storageApi.test.ts.snap
+++ b/test/__snapshots__/storageApi.test.ts.snap
@@ -48,12 +48,7 @@ Object {
 }
 `;
 
-exports[`Get bucket with wrong id 1`] = `
-Object {
-  "message": "The resource was not found",
-  "status": 400,
-}
-`;
+exports[`Get bucket with wrong id 1`] = `[StorageApiError: The resource was not found]`;
 
 exports[`delete bucket 1`] = `
 Object {


### PR DESCRIPTION
Fixes #55.

## What is the current behaviour?

There are some type errors, and functions return everything with `| null`, making it difficult for end-users to work with.

## What is the new behaviour?

Functions now return type unions, which are more correct and easier to work with.

## Additional context

I've labelled this as `feat` instead of `chore` as it should be treated as a **breaking change** because it may show new type errors to existing users.
