### PR TITLE
Improve function return types

### DIFF
--- a/src/lib/StorageBucketApi.ts
+++ b/src/lib/StorageBucketApi.ts
@@ -17,11 +17,11 @@ export class StorageBucketApi {
   /**
    * Retrieves the details of all Storage buckets within an existing project.
    */
-  async listBuckets(): Promise<{ data: Bucket[] | null; error: Error | null }> {
+  async listBuckets(): Promise<{ data: Bucket[]; error: null } | { data: null; error: Error }> {
     try {
       const data = await get(this.fetch, `${this.url}/bucket`, { headers: this.headers })
       return { data, error: null }
-    } catch (error) {
+    } catch (error: any) {
       return { data: null, error }
     }
   }
@@ -31,11 +31,13 @@ export class StorageBucketApi {
    *
    * @param id The unique identifier of the bucket you would like to retrieve.
    */
-  async getBucket(id: string): Promise<{ data: Bucket | null; error: Error | null }> {
+  async getBucket(
+    id: string
+  ): Promise<{ data: Bucket; error: null } | { data: null; error: Error }> {
     try {
       const data = await get(this.fetch, `${this.url}/bucket/${id}`, { headers: this.headers })
       return { data, error: null }
-    } catch (error) {
+    } catch (error: any) {
       return { data: null, error }
     }
   }
@@ -49,7 +51,7 @@ export class StorageBucketApi {
   async createBucket(
     id: string,
     options: { public: boolean } = { public: false }
-  ): Promise<{ data: string | null; error: Error | null }> {
+  ): Promise<{ data: string; error: null } | { data: null; error: Error }> {
     try {
       const data = await post(
         this.fetch,
@@ -58,7 +60,7 @@ export class StorageBucketApi {
         { headers: this.headers }
       )
       return { data: data.name, error: null }
-    } catch (error) {
+    } catch (error: any) {
       return { data: null, error }
     }
   }
@@ -71,7 +73,7 @@ export class StorageBucketApi {
   async updateBucket(
     id: string,
     options: { public: boolean }
-  ): Promise<{ data: { message: string } | null; error: Error | null }> {
+  ): Promise<{ data: { message: string }; error: null } | { data: null; error: Error }> {
     try {
       const data = await put(
         this.fetch,
@@ -80,7 +82,7 @@ export class StorageBucketApi {
         { headers: this.headers }
       )
       return { data, error: null }
-    } catch (error) {
+    } catch (error: any) {
       return { data: null, error }
     }
   }
@@ -92,7 +94,7 @@ export class StorageBucketApi {
    */
   async emptyBucket(
     id: string
-  ): Promise<{ data: { message: string } | null; error: Error | null }> {
+  ): Promise<{ data: { message: string }; error: null } | { data: null; error: Error }> {
     try {
       const data = await post(
         this.fetch,
@@ -101,7 +103,7 @@ export class StorageBucketApi {
         { headers: this.headers }
       )
       return { data, error: null }
-    } catch (error) {
+    } catch (error: any) {
       return { data: null, error }
     }
   }
@@ -114,7 +116,7 @@ export class StorageBucketApi {
    */
   async deleteBucket(
     id: string
-  ): Promise<{ data: { message: string } | null; error: Error | null }> {
+  ): Promise<{ data: { message: string }; error: null } | { data: null; error: Error }> {
     try {
       const data = await remove(
         this.fetch,
@@ -123,7 +125,7 @@ export class StorageBucketApi {
         { headers: this.headers }
       )
       return { data, error: null }
-    } catch (error) {
+    } catch (error: any) {
       return { data: null, error }
     }
   }

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -61,7 +61,7 @@ export class StorageFileApi {
       | URLSearchParams
       | string,
     fileOptions?: FileOptions
-  ): Promise<{ data: { Key: string } | null; error: Error | null }> {
+  ): Promise<{ data: { Key: string }; error: null } | { data: null; error: Error }> {
     try {
       let body
       const options = { ...DEFAULT_FILE_OPTIONS, ...fileOptions }
@@ -99,7 +99,7 @@ export class StorageFileApi {
         const error = await res.json()
         return { data: null, error }
       }
-    } catch (error) {
+    } catch (error: any) {
       return { data: null, error }
     }
   }
@@ -128,7 +128,7 @@ export class StorageFileApi {
       | URLSearchParams
       | string,
     fileOptions?: FileOptions
-  ): Promise<{ data: { Key: string } | null; error: Error | null }> {
+  ): Promise<{ data: { Key: string }; error: null } | { data: null; error: Error }> {
     return this.uploadOrUpdate('POST', path, fileBody, fileOptions)
   }
 
@@ -156,7 +156,7 @@ export class StorageFileApi {
       | URLSearchParams
       | string,
     fileOptions?: FileOptions
-  ): Promise<{ data: { Key: string } | null; error: Error | null }> {
+  ): Promise<{ data: { Key: string }; error: null } | { data: null; error: Error }> {
     return this.uploadOrUpdate('PUT', path, fileBody, fileOptions)
   }
 
@@ -169,7 +169,7 @@ export class StorageFileApi {
   async move(
     fromPath: string,
     toPath: string
-  ): Promise<{ data: { message: string } | null; error: Error | null }> {
+  ): Promise<{ data: { Key: string }; error: null } | { data: null; error: Error }> {
     try {
       const data = await post(
         this.fetch,
@@ -178,7 +178,7 @@ export class StorageFileApi {
         { headers: this.headers }
       )
       return { data, error: null }
-    } catch (error) {
+    } catch (error: any) {
       return { data: null, error }
     }
   }
@@ -192,7 +192,7 @@ export class StorageFileApi {
   async copy(
     fromPath: string,
     toPath: string
-  ): Promise<{ data: { message: string } | null; error: Error | null }> {
+  ): Promise<{ data: { Key: string }; error: null } | { data: null; error: Error }> {
     try {
       const data = await post(
         this.fetch,
@@ -201,7 +201,7 @@ export class StorageFileApi {
         { headers: this.headers }
       )
       return { data, error: null }
-    } catch (error) {
+    } catch (error: any) {
       return { data: null, error }
     }
   }
@@ -215,11 +215,18 @@ export class StorageFileApi {
   async createSignedUrl(
     path: string,
     expiresIn: number
-  ): Promise<{
-    data: { signedURL: string } | null
-    error: Error | null
-    signedURL: string | null
-  }> {
+  ): Promise<
+    | {
+        data: { signedURL: string }
+        error: null
+        signedURL: string
+      }
+    | {
+        data: null
+        error: Error
+        signedURL: null
+      }
+  > {
     try {
       const _path = this._getFinalPath(path)
       let data = await post(
@@ -231,7 +238,7 @@ export class StorageFileApi {
       const signedURL = `${this.url}${data.signedURL}`
       data = { signedURL }
       return { data, error: null, signedURL }
-    } catch (error) {
+    } catch (error: any) {
       return { data: null, error, signedURL: null }
     }
   }
@@ -245,10 +252,16 @@ export class StorageFileApi {
   async createSignedUrls(
     paths: string[],
     expiresIn: number
-  ): Promise<{
-    data: { error: string | null; path: string | null; signedURL: string }[] | null
-    error: Error | null
-  }> {
+  ): Promise<
+    | {
+        data: { path: string; signedURL: string }[]
+        error: null
+      }
+    | {
+        data: null
+        error: Error
+      }
+  > {
     try {
       const data = await post(
         this.fetch,
@@ -263,7 +276,7 @@ export class StorageFileApi {
         })),
         error: null,
       }
-    } catch (error) {
+    } catch (error: any) {
       return { data: null, error }
     }
   }
@@ -273,7 +286,9 @@ export class StorageFileApi {
    *
    * @param path The file path to be downloaded, including the path and file name. For example `folder/image.png`.
    */
-  async download(path: string): Promise<{ data: Blob | null; error: Error | null }> {
+  async download(
+    path: string
+  ): Promise<{ data: Blob; error: null } | { data: null; error: Error }> {
     try {
       const _path = this._getFinalPath(path)
       const res = await get(this.fetch, `${this.url}/object/${_path}`, {
@@ -282,7 +297,7 @@ export class StorageFileApi {
       })
       const data = await res.blob()
       return { data, error: null }
-    } catch (error) {
+    } catch (error: any) {
       return { data: null, error }
     }
   }
@@ -294,17 +309,23 @@ export class StorageFileApi {
    */
   getPublicUrl(
     path: string
-  ): {
-    data: { publicURL: string } | null
-    error: Error | null
-    publicURL: string | null
-  } {
+  ):
+    | {
+        data: { publicURL: string }
+        error: null
+        publicURL: string
+      }
+    | {
+        data: null
+        error: Error
+        publicURL: null
+      } {
     try {
       const _path = this._getFinalPath(path)
       const publicURL = `${this.url}/object/public/${_path}`
       const data = { publicURL }
       return { data, error: null, publicURL }
-    } catch (error) {
+    } catch (error: any) {
       return { data: null, error, publicURL: null }
     }
   }
@@ -314,7 +335,9 @@ export class StorageFileApi {
    *
    * @param paths An array of files to be deleted, including the path and file name. For example [`folder/image.png`].
    */
-  async remove(paths: string[]): Promise<{ data: FileObject[] | null; error: Error | null }> {
+  async remove(
+    paths: string[]
+  ): Promise<{ data: FileObject[]; error: null } | { data: null; error: Error }> {
     try {
       const data = await remove(
         this.fetch,
@@ -323,7 +346,7 @@ export class StorageFileApi {
         { headers: this.headers }
       )
       return { data, error: null }
-    } catch (error) {
+    } catch (error: any) {
       return { data: null, error }
     }
   }
@@ -368,7 +391,7 @@ export class StorageFileApi {
     path?: string,
     options?: SearchOptions,
     parameters?: FetchParameters
-  ): Promise<{ data: FileObject[] | null; error: Error | null }> {
+  ): Promise<{ data: FileObject[]; error: null } | { data: null; error: Error }> {
     try {
       const body = { ...DEFAULT_SEARCH_OPTIONS, ...options, prefix: path || '' }
       const data = await post(
@@ -379,7 +402,7 @@ export class StorageFileApi {
         parameters
       )
       return { data, error: null }
-    } catch (error) {
+    } catch (error: any) {
       return { data: null, error }
     }
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?


## What is the current behavior?

Fixes #55 

Currently, the return type for most functions is:

```javascript
Promise<{ data: { Key: string } | null; error: Error | null }>
```

Which means that a return type of either `{null, null}` or `{{key: string}, Error}` is technically possible even though it would not make any sense, so we have to manually check that data AND error are not null.

## What is the new behavior?

By changing the return types to something like:

```javascript
Promise<{ data: { Key: string }; error: null } | { data: null; error: Error }>
```

We basically narrow it down to `data or error`, not `data and/or error` as a possible return.
This also makes sure that we don't accidentally return `{null, null}`, for example, which would not have been reported as an error by typescript before.

## Additional context

I also noticed that most of the `try... catch` blocks would show a warning because the `error` variable in `catch (error)` is not typed so it was reporting as `unknown` and unknown cannot be cast to either Error or null. As such, I also modified all `try... catch` statements to cast `error` as `Error` in the meantime. Eventually, some custom errors would be required, i think:

```javascript
try {
...
} catch (error: any) {
  return { data: null, error } // no longer showing a warning for error being an unknown type
}
```