### PR TITLE
Improve `getPublicUrl`

### DIFF
--- a/src/lib/StorageBucketApi.ts
+++ b/src/lib/StorageBucketApi.ts
@@ -66,7 +66,7 @@ export class StorageBucketApi {
   /**
    * Updates a new Storage bucket
    *
-   * @param id A unique identifier for the bucket you are creating.
+   * @param id A unique identifier for the bucket you are updating.
    */
   async updateBucket(
     id: string,

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -297,11 +297,12 @@ export class StorageFileApi {
   ): {
     data: { publicURL: string }
     error: null
+    publicURL: string
   } {
     const _path = this._getFinalPath(path)
     const publicURL = `${this.url}/object/public/${_path}`
     const data = { publicURL }
-    return { data, error: null }
+    return { data, error: null, publicURL }
   }
 
   /**

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -392,17 +392,9 @@ export class StorageFileApi {
    *
    * @param path The file path to be downloaded, including the path and file name. For example `folder/image.png`.
    */
-  getPublicUrl(
-    path: string
-  ): {
-    data: { publicURL: string }
-    error: null
-    publicURL: string
-  } {
+  getPublicUrl(path: string): string {
     const _path = this._getFinalPath(path)
-    const publicURL = `${this.url}/object/public/${_path}`
-    const data = { publicURL }
-    return { data, error: null, publicURL }
+    return `${this.url}/object/public/${_path}`
   }
 
   /**

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -398,15 +398,6 @@ export class StorageFileApi {
   }
 
   /**
-   * Retrieve URLs for assets in public buckets and returns ONLY the url as a string
-   *
-   * @param path The file path to be downloaded, including the path and file name. For example `folder/image.png`.
-   */
-  getPublicUrlAsString(path: string): string {
-    return this.getPublicUrl(path).data.publicURL
-  }
-
-  /**
    * Deletes files within the same bucket
    *
    * @param paths An array of files to be deleted, including the path and file name. For example [`folder/image.png`].

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -288,25 +288,30 @@ export class StorageFileApi {
   }
 
   /**
-   * Retrieve URLs for assets in public buckets
+   * Retrieve URLs for assets in public buckets and encapsulates it in a return object
    *
    * @param path The file path to be downloaded, including the path and file name. For example `folder/image.png`.
    */
   getPublicUrl(
     path: string
   ): {
-    data: { publicURL: string } | null
-    error: Error | null
-    publicURL: string | null
+    data: { publicURL: string }
+    error: null
+    publicURL: string
   } {
-    try {
-      const _path = this._getFinalPath(path)
-      const publicURL = `${this.url}/object/public/${_path}`
-      const data = { publicURL }
-      return { data, error: null, publicURL }
-    } catch (error) {
-      return { data: null, error, publicURL: null }
-    }
+    const _path = this._getFinalPath(path)
+    const publicURL = `${this.url}/object/public/${_path}`
+    const data = { publicURL }
+    return { data, error: null, publicURL }
+  }
+
+  /**
+   * Retrieve URLs for assets in public buckets and returns ONLY the url as a string
+   *
+   * @param path The file path to be downloaded, including the path and file name. For example `folder/image.png`.
+   */
+  getPublicUrlAsString(path: string): string {
+    return this.getPublicUrl(path).publicURL
   }
 
   /**

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -297,12 +297,11 @@ export class StorageFileApi {
   ): {
     data: { publicURL: string }
     error: null
-    publicURL: string
   } {
     const _path = this._getFinalPath(path)
     const publicURL = `${this.url}/object/public/${_path}`
     const data = { publicURL }
-    return { data, error: null, publicURL }
+    return { data, error: null }
   }
 
   /**
@@ -311,7 +310,7 @@ export class StorageFileApi {
    * @param path The file path to be downloaded, including the path and file name. For example `folder/image.png`.
    */
   getPublicUrlAsString(path: string): string {
-    return this.getPublicUrl(path).publicURL
+    return this.getPublicUrl(path).data.publicURL
   }
 
   /**

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,5 +1,3 @@
-import crossFetch from 'cross-fetch'
-
 type Fetch = typeof fetch
 
 export const resolveFetch = (customFetch?: Fetch): Fetch => {
@@ -7,7 +5,7 @@ export const resolveFetch = (customFetch?: Fetch): Fetch => {
   if (customFetch) {
     _fetch = customFetch
   } else if (typeof fetch === 'undefined') {
-    _fetch = (crossFetch as unknown) as Fetch
+    _fetch = async (...args) => await (await import('cross-fetch')).fetch(...args)
   } else {
     _fetch = fetch
   }

--- a/test/__snapshots__/storageFileApi.test.ts.snap
+++ b/test/__snapshots__/storageFileApi.test.ts.snap
@@ -1,9 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`get public URL 1`] = `
-Object {
-  "publicURL": "http://localhost:8000/storage/v1/object/public/my-new-public-bucket/profiles/myUniqueUserId/profile.png",
-}
-`;
-
-exports[`get public URL 2`] = `"http://localhost:8000/storage/v1/object/public/my-new-public-bucket/profiles/myUniqueUserId/profile.png"`;
+exports[`get public URL 1`] = `"http://localhost:8000/storage/v1/object/public/my-new-public-bucket/profiles/myUniqueUserId/profile.png"`;

--- a/test/storageFileApi.test.ts
+++ b/test/storageFileApi.test.ts
@@ -8,9 +8,7 @@ const KEY =
 const storage = new StorageClient(URL, { Authorization: `Bearer ${KEY}` })
 const newBucketName = 'my-new-public-bucket'
 
-test('get public URL', async () => {
+test('get public URL', () => {
   const res = storage.from(newBucketName).getPublicUrl('profiles/myUniqueUserId/profile.png')
-  expect(res.error).toBeNull()
-  expect(res.data).toMatchSnapshot()
-  expect(res.publicURL).toMatchSnapshot()
+  expect(res).toMatchSnapshot()
 })

--- a/tsconfig.module.json
+++ b/tsconfig.module.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "module": "ES2015",
+    "module": "ES2020",
     "outDir": "dist/module"
   }
 }


### PR DESCRIPTION
Fixes #53 and #27 

## What is the current behavior?

Currently, `getPublicUrl` is looking like this:

```javascript
getPublicUrl(
  path: string
): {
  data: { publicURL: string } | null
  error: Error | null
  publicURL: string | null
} {
  try {
    const _path = this._getFinalPath(path)
    const publicURL = `${this.url}/object/public/${_path}`
    const data = { publicURL }
    return { data, error: null, publicURL }
  } catch (error) {
    return { data: null, error, publicURL: null }
  }
}
```

Which is not ideal because:

1. The `try... catch` doesn't really make much sense as all that happens inside the function, at least to  my understanding, is string concatenation of values that are not null thanks to typescript.
2. The error will always be `null`.
3. The return type is inconsistent with the other methods. They all return `{data, error}` and this would be the only one to return `{{data_contents}, error, data_contents}`.

## What is the new behavior?

My suggestion is to:

1. Remove the `try catch` from the function
2. Change the return type to `{data, error}` to match the other methods
3. Create an additional method, something like `getPublicUrlAsString` that would only return a `string` of the public url.

This way, we provide backwards compatibility by leaving the old method in place (though removing the publicUrl from the return type may be questionable in this regard, so we may have to leave it in) and we also provide a better `getPublicUrl` method from now on that simply returns the string.

## Additional context

Add any other context or screenshots.
