### PR TITLE
Improve `uploadOrUpdate` returned data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,12 @@ const storageClient = new SupabaseStorageClient(STORAGE_URL, {
 
   > Note:  
   > The path in `data.key` is prefixed by the bucket ID and is not the value which should be passed to the `download` method in order to fetch the file.  
-  > To fetch the file via the `download` method, use `data.downloadPath`.  
-  > Example:
+  > To fetch the file via the `download` method, use `data.downloadPath` and `data.bucketId` as follows:
   >
   > ```javascript
   > const { data, error } = await storageClient.from('bucket').upload('/folder/file.txt', fileBody)
   > // check for errors
-  > const { data2, error2 } = await storageClient.from('bucket').download(data.downloadPath)
+  > const { data2, error2 } = await storageClient.from(data.bucketId).download(data.downloadPath)
   > ```
 
   > Note: The `upload` method also accepts a map of optional parameters. For a complete list see the [Supabase API reference](https://supabase.com/docs/reference/javascript/storage-from-upload).

--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ const storageClient = new SupabaseStorageClient(STORAGE_URL, {
 
   > Note:  
   > The path in `data.Key` is prefixed by the bucket ID and is not the value which should be passed to the `download` method in order to fetch the file.  
-  > To fetch the file via the `download` method, use `data.downloadPath` and `data.bucketId` as follows:
+  > To fetch the file via the `download` method, use `data.path` and `data.bucketId` as follows:
   >
   > ```javascript
   > const { data, error } = await storageClient.from('bucket').upload('/folder/file.txt', fileBody)
   > // check for errors
-  > const { data2, error2 } = await storageClient.from(data.bucketId).download(data.downloadPath)
+  > const { data2, error2 } = await storageClient.from(data.bucketId).download(data.path)
   > ```
 
   > Note: The `upload` method also accepts a map of optional parameters. For a complete list see the [Supabase API reference](https://supabase.com/docs/reference/javascript/storage-from-upload).

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ const storageClient = new SupabaseStorageClient(STORAGE_URL, {
   ```
 
   > Note:  
-  > The path in `data.key` is prefixed by the bucket ID and is not the value which should be passed to the `download` method in order to fetch the file.  
+  > The path in `data.Key` is prefixed by the bucket ID and is not the value which should be passed to the `download` method in order to fetch the file.  
   > To fetch the file via the `download` method, use `data.downloadPath` and `data.bucketId` as follows:
   >
   > ```javascript

--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ const storageClient = new SupabaseStorageClient(STORAGE_URL, {
   const { data, error } = await storageClient.from('bucket').upload('path/to/file', fileBody)
   ```
 
+  > Note:  
+  > The path in `data.key` is prefixed by the bucket ID and is not the value which should be passed to the `download` method in order to fetch the file.  
+  > To fetch the file via the `download` method, use `data.downloadPath`.  
+  > Example:
+  >
+  > ```javascript
+  > const { data, error } = await storageClient.from('bucket').upload('/folder/file.txt', fileBody)
+  > // check for errors
+  > const { data2, error2 } = await storageClient.from('bucket').download(data.downloadPath)
+  > ```
+
   > Note: The `upload` method also accepts a map of optional parameters. For a complete list see the [Supabase API reference](https://supabase.com/docs/reference/javascript/storage-from-upload).
 
 - Download a file from an exisiting bucket:
@@ -128,7 +139,7 @@ const storageClient = new SupabaseStorageClient(STORAGE_URL, {
 
   ```js
   const expireIn = 60
-  
+
   const { data, error } = await storageClient
     .from('bucket')
     .createSignedUrl('path/to/file', expireIn)

--- a/src/lib/StorageBucketApi.ts
+++ b/src/lib/StorageBucketApi.ts
@@ -108,7 +108,7 @@ export class StorageBucketApi {
   /**
    * Updates a new Storage bucket
    *
-   * @param id A unique identifier for the bucket you are creating.
+   * @param id A unique identifier for the bucket you are updating.
    */
   async updateBucket(
     id: string,

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -62,7 +62,10 @@ export class StorageFileApi {
       | URLSearchParams
       | string,
     fileOptions?: FileOptions
-  ): Promise<{ data: { Key: string; downloadPath: string } | null; error: Error | null }> {
+  ): Promise<{
+    data: { Key: string; downloadPath: string; bucketId?: string } | null
+    error: Error | null
+  }> {
     try {
       let body
       const options = { ...DEFAULT_FILE_OPTIONS, ...fileOptions }
@@ -95,7 +98,10 @@ export class StorageFileApi {
       if (res.ok) {
         // const data = await res.json()
         // temporary fix till backend is updated to the latest storage-api version
-        return { data: { Key: _path, downloadPath: cleanPath }, error: null }
+        return {
+          data: { Key: _path, downloadPath: cleanPath, bucketId: this.bucketId },
+          error: null,
+        }
       } else {
         const error = await res.json()
         return { data: null, error }

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -63,7 +63,7 @@ export class StorageFileApi {
       | string,
     fileOptions?: FileOptions
   ): Promise<{
-    data: { Key: string; downloadPath: string; bucketId?: string } | null
+    data: { Key: string; path: string; bucketId?: string } | null
     error: Error | null
   }> {
     try {
@@ -99,7 +99,7 @@ export class StorageFileApi {
         // const data = await res.json()
         // temporary fix till backend is updated to the latest storage-api version
         return {
-          data: { Key: _path, downloadPath: cleanPath, bucketId: this.bucketId },
+          data: { Key: _path, path: cleanPath, bucketId: this.bucketId },
           error: null,
         }
       } else {
@@ -140,7 +140,7 @@ export class StorageFileApi {
       | string,
     fileOptions?: FileOptions
   ): Promise<{
-    data: { Key: string; downloadPath: string; bucketId?: string } | null
+    data: { Key: string; path: string; bucketId?: string } | null
     error: Error | null
   }> {
     return this.uploadOrUpdate('POST', path, fileBody, fileOptions)
@@ -171,7 +171,7 @@ export class StorageFileApi {
       | string,
     fileOptions?: FileOptions
   ): Promise<{
-    data: { Key: string; downloadPath: string; bucketId?: string } | null
+    data: { Key: string; path: string; bucketId?: string } | null
     error: Error | null
   }> {
     return this.uploadOrUpdate('PUT', path, fileBody, fileOptions)

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -139,7 +139,10 @@ export class StorageFileApi {
       | URLSearchParams
       | string,
     fileOptions?: FileOptions
-  ): Promise<{ data: { Key: string; downloadPath: string } | null; error: Error | null }> {
+  ): Promise<{
+    data: { Key: string; downloadPath: string; bucketId?: string } | null
+    error: Error | null
+  }> {
     return this.uploadOrUpdate('POST', path, fileBody, fileOptions)
   }
 
@@ -167,7 +170,10 @@ export class StorageFileApi {
       | URLSearchParams
       | string,
     fileOptions?: FileOptions
-  ): Promise<{ data: { Key: string; downloadPath: string } | null; error: Error | null }> {
+  ): Promise<{
+    data: { Key: string; downloadPath: string; bucketId?: string } | null
+    error: Error | null
+  }> {
     return this.uploadOrUpdate('PUT', path, fileBody, fileOptions)
   }
 

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -62,10 +62,16 @@ export class StorageFileApi {
       | URLSearchParams
       | string,
     fileOptions?: FileOptions
-  ): Promise<{
-    data: { Key: string; path: string; bucketId?: string } | null
-    error: Error | null
-  }> {
+  ): Promise<
+    | {
+        data: { Key: string; path: string; bucketId?: string }
+        error: null
+      }
+    | {
+        data: null
+        error: StorageError
+      }
+  > {
     try {
       let body
       const options = { ...DEFAULT_FILE_OPTIONS, ...fileOptions }
@@ -139,10 +145,16 @@ export class StorageFileApi {
       | URLSearchParams
       | string,
     fileOptions?: FileOptions
-  ): Promise<{
-    data: { Key: string; path: string; bucketId?: string } | null
-    error: Error | null
-  }> {
+  ): Promise<
+    | {
+        data: { Key: string; path: string; bucketId?: string }
+        error: null
+      }
+    | {
+        data: null
+        error: StorageError
+      }
+  > {
     return this.uploadOrUpdate('POST', path, fileBody, fileOptions)
   }
 
@@ -170,10 +182,16 @@ export class StorageFileApi {
       | URLSearchParams
       | string,
     fileOptions?: FileOptions
-  ): Promise<{
-    data: { Key: string; path: string; bucketId?: string } | null
-    error: Error | null
-  }> {
+  ): Promise<
+    | {
+        data: { Key: string; path: string; bucketId?: string }
+        error: null
+      }
+    | {
+        data: null
+        error: StorageError
+      }
+  > {
     return this.uploadOrUpdate('PUT', path, fileBody, fileOptions)
   }
 

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -62,18 +62,7 @@ export class StorageFileApi {
       | URLSearchParams
       | string,
     fileOptions?: FileOptions
-  ): Promise<
-    | {
-        data: {
-          Key: string
-        }
-        error: null
-      }
-    | {
-        data: null
-        error: StorageError
-      }
-  > {
+  ): Promise<{ data: { Key: string; downloadPath: string } | null; error: Error | null }> {
     try {
       let body
       const options = { ...DEFAULT_FILE_OPTIONS, ...fileOptions }
@@ -106,7 +95,7 @@ export class StorageFileApi {
       if (res.ok) {
         // const data = await res.json()
         // temporary fix till backend is updated to the latest storage-api version
-        return { data: { Key: _path }, error: null }
+        return { data: { Key: _path, downloadPath: cleanPath }, error: null }
       } else {
         const error = await res.json()
         return { data: null, error }
@@ -144,18 +133,7 @@ export class StorageFileApi {
       | URLSearchParams
       | string,
     fileOptions?: FileOptions
-  ): Promise<
-    | {
-        data: {
-          Key: string
-        }
-        error: null
-      }
-    | {
-        data: null
-        error: StorageError
-      }
-  > {
+  ): Promise<{ data: { Key: string; downloadPath: string } | null; error: Error | null }> {
     return this.uploadOrUpdate('POST', path, fileBody, fileOptions)
   }
 
@@ -183,18 +161,7 @@ export class StorageFileApi {
       | URLSearchParams
       | string,
     fileOptions?: FileOptions
-  ): Promise<
-    | {
-        data: {
-          Key: string
-        }
-        error: null
-      }
-    | {
-        data: null
-        error: StorageError
-      }
-  > {
+  ): Promise<{ data: { Key: string; downloadPath: string } | null; error: Error | null }> {
     return this.uploadOrUpdate('PUT', path, fileBody, fileOptions)
   }
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -7,7 +7,7 @@ export const resolveFetch = (customFetch?: Fetch): Fetch => {
   if (customFetch) {
     _fetch = customFetch
   } else if (typeof fetch === 'undefined') {
-    _fetch = (crossFetch as unknown) as Fetch
+    _fetch = async (...args) => await (await import('cross-fetch')).fetch(...args)
   } else {
     _fetch = fetch
   }

--- a/tsconfig.module.json
+++ b/tsconfig.module.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "module": "ES2015",
+    "module": "ES2020",
     "outDir": "dist/module"
   }
 }


### PR DESCRIPTION
Fixes #9 

## What is the current behavior?

Currently, the `uploadOrUpdate` function (so automatically the `upload` and `update` functions as well), only returns a `Key: value` pair that represents the file path prefixed by the bucket id.

This path cannot be then passed to the `download` method as the download doesn't need the bucket id prefix.

## What is the new behavior?

By simply adding 2 more `Key: value` pairs to the returned `data` object, we can provide more useful information in the returned object:

```javascript
{
  Key: the old path, for backwards compatibility
  downloadPath: the path not prefixed by the bucket ID
  bucketId: the id of the bucket
}
```

By also providing the bucket ID in the returned data, we give users the full set on information required to be able to call `download`, as I assume that the data returned from `upload` will then immediately be stored in the database for later use.

By implementing these changes, we enable a workflow similar to this:

```javascript
const { data, error } = await storageClient.from('bucket').upload('/folder/file.txt', fileBody)
// ...
const { data2, error2 } = await storageClient.from(data.bucketId).download(data.downloadPath)
```
