### PR TITLE
[POC] chore: use getHeaders

### DIFF
--- a/src/StorageClient.ts
+++ b/src/StorageClient.ts
@@ -1,9 +1,14 @@
 import { StorageBucketApi, StorageFileApi } from './lib'
 import { Fetch } from './lib/fetch'
+import { noopPromise } from './lib/helpers'
 
 export class StorageClient extends StorageBucketApi {
-  constructor(url: string, headers: { [key: string]: string } = {}, fetch?: Fetch) {
-    super(url, headers, fetch)
+  constructor(
+    url: string,
+    getHeaders: () => Promise<{ [key: string]: string }> | { [key: string]: string } = noopPromise,
+    fetch?: Fetch
+  ) {
+    super(url, getHeaders, fetch)
   }
 
   /**
@@ -12,6 +17,6 @@ export class StorageClient extends StorageBucketApi {
    * @param id The bucket id to operate on.
    */
   from(id: string): StorageFileApi {
-    return new StorageFileApi(this.url, this.headers, id, this.fetch)
+    return new StorageFileApi(this.url, this.getHeaders, id, this.fetch)
   }
 }

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -13,3 +13,5 @@ export const resolveFetch = (customFetch?: Fetch): Fetch => {
   }
   return (...args) => _fetch(...args)
 }
+
+export const noopPromise = () => Promise.resolve({})

--- a/test/storageApi.test.ts
+++ b/test/storageApi.test.ts
@@ -5,7 +5,7 @@ const URL = 'http://localhost:8000/storage/v1'
 const KEY =
   'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzdXBhYmFzZSIsImlhdCI6MTYwMzk2ODgzNCwiZXhwIjoyNTUwNjUzNjM0LCJhdWQiOiIiLCJzdWIiOiIzMTdlYWRjZS02MzFhLTQ0MjktYTBiYi1mMTlhN2E1MTdiNGEiLCJSb2xlIjoicG9zdGdyZXMifQ.pZobPtp6gDcX0UbzMmG3FHSlg4m4Q-22tKtGWalOrNo'
 
-const storage = new StorageBucketApi(URL, { Authorization: `Bearer ${KEY}` })
+const storage = new StorageBucketApi(URL, () => ({ Authorization: `Bearer ${KEY}` }))
 const newBucketName = `my-new-bucket-${Date.now()}`
 
 test('Build to succeed', async () => {

--- a/test/storageFileApi.test.ts
+++ b/test/storageFileApi.test.ts
@@ -5,7 +5,7 @@ const URL = 'http://localhost:8000/storage/v1'
 const KEY =
   'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzdXBhYmFzZSIsImlhdCI6MTYwMzk2ODgzNCwiZXhwIjoyNTUwNjUzNjM0LCJhdWQiOiIiLCJzdWIiOiIzMTdlYWRjZS02MzFhLTQ0MjktYTBiYi1mMTlhN2E1MTdiNGEiLCJSb2xlIjoicG9zdGdyZXMifQ.pZobPtp6gDcX0UbzMmG3FHSlg4m4Q-22tKtGWalOrNo'
 
-const storage = new StorageClient(URL, { Authorization: `Bearer ${KEY}` })
+const storage = new StorageClient(URL, () => ({ Authorization: `Bearer ${KEY}` }))
 const newBucketName = 'my-new-public-bucket'
 
 test('get public URL', async () => {


### PR DESCRIPTION
Implements a new `getHeaders` function instead of a static headers object.

This relates to https://github.com/supabase/gotrue-js/pull/285

This can also be made as a non-breaking change by allowing an object to still be passed in place of the function, but I think since we're already making some breaking changes, we should favour API simplicity.