### PR TITLE
upload, update: don't return bucketId

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# generated docs
+docs

--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -64,7 +64,7 @@ export class StorageFileApi {
     fileOptions?: FileOptions
   ): Promise<
     | {
-        data: { Key: string; path: string; bucketId?: string }
+        data: { path: string }
         error: null
       }
     | {
@@ -102,10 +102,8 @@ export class StorageFileApi {
       })
 
       if (res.ok) {
-        // const data = await res.json()
-        // temporary fix till backend is updated to the latest storage-api version
         return {
-          data: { Key: _path, path: cleanPath, bucketId: this.bucketId },
+          data: { path: cleanPath },
           error: null,
         }
       } else {
@@ -147,7 +145,7 @@ export class StorageFileApi {
     fileOptions?: FileOptions
   ): Promise<
     | {
-        data: { Key: string; path: string; bucketId?: string }
+        data: { path: string }
         error: null
       }
     | {
@@ -184,7 +182,7 @@ export class StorageFileApi {
     fileOptions?: FileOptions
   ): Promise<
     | {
-        data: { Key: string; path: string; bucketId?: string }
+        data: { path: string }
         error: null
       }
     | {


### PR DESCRIPTION
as a return parameter and in the path. Just returning the path without the bucket id makes it easier to pass the value in to other storage-js functions. Also not calling it Key -- was uppercase and not as clear as just calling it path.