### PR TITLE
fix: remove release config from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,11 +62,6 @@
   },
   "jsdelivr": "dist/umd/supabase.js",
   "unpkg": "dist/umd/supabase.js",
-  "release": {
-    "branches": [
-      "main"
-    ]
-  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
It looks like we were doubling up on release configs