### PR TITLE
fix: encode all urls

### DIFF
--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -294,7 +294,7 @@ export class StorageFileApi {
         { expiresIn },
         { headers: this.headers }
       )
-      const signedURL = `${this.url}${data.signedURL}`
+      const signedURL = encodeURI(`${this.url}${data.signedURL}`)
       data = { signedURL }
       return { data, error: null, signedURL }
     } catch (error) {
@@ -335,7 +335,7 @@ export class StorageFileApi {
       return {
         data: data.map((datum: { signedURL: string }) => ({
           ...datum,
-          signedURL: datum.signedURL ? `${this.url}${datum.signedURL}` : null,
+          signedURL: datum.signedURL ? encodeURI(`${this.url}${datum.signedURL}`) : null,
         })),
         error: null,
       }
@@ -389,7 +389,7 @@ export class StorageFileApi {
    */
   getPublicUrl(path: string): string {
     const _path = this._getFinalPath(path)
-    return `${this.url}/object/public/${_path}`
+    return encodeURI(`${this.url}/object/public/${_path}`)
   }
 
   /**


### PR DESCRIPTION
fixes https://github.com/supabase/storage-js/issues/78

Encodes URLs in `createSignedUrl`, `createSignedUrls` and `getPublicUrl`

this should ideally be done in the api server, but doing this breaking change at the client library first, so when we do it at the backend, only folks who are using the api directly will need to upgrade.