### PR TITLE
feat: add metadata properties

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -44,7 +44,9 @@ export interface SearchOptions {
   search?: string
 }
 
-// TODO: need to check for metadata props. The api swagger doesnt have.
 export interface Metadata {
   name: string
+  size?: number
+  mimetype?: string
+  cacheControl?: string
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature where we add some metadata properties. 

One user of the Dart SDK asked for this, and thought might as well add it to the js sdk as well, but please feel free to close this if it interferes with anything that is planned!

## What is the current behavior?

`name` is the only property in `metadata`.

## What is the new behavior?

`metadata` now has `size`, `mimetype` and `cachControl`. These were the ones that I was able to find with a quick glance. 

