### PR TITLE
fix: signed URLs return value

### DIFF
--- a/src/lib/StorageFileApi.ts
+++ b/src/lib/StorageFileApi.ts
@@ -278,12 +278,10 @@ export class StorageFileApi {
     | {
         data: { signedURL: string }
         error: null
-        signedURL: string
       }
     | {
         data: null
         error: StorageError
-        signedURL: null
       }
   > {
     try {
@@ -296,10 +294,10 @@ export class StorageFileApi {
       )
       const signedURL = encodeURI(`${this.url}${data.signedURL}`)
       data = { signedURL }
-      return { data, error: null, signedURL }
+      return { data, error: null }
     } catch (error) {
       if (isStorageError(error)) {
-        return { data: null, error, signedURL: null }
+        return { data: null, error }
       }
 
       throw error


### PR DESCRIPTION
signedURL used to return a url directly and inside the data object. This is inconsistent. Now we always return values inside a data object only.