### PR TITLE
fix: createBucket pass through all values returned by backend

### DIFF
--- a/src/lib/StorageBucketApi.ts
+++ b/src/lib/StorageBucketApi.ts
@@ -80,7 +80,7 @@ export class StorageBucketApi {
     options: { public: boolean } = { public: false }
   ): Promise<
     | {
-        data: string
+        data: Pick<Bucket, 'name'>
         error: null
       }
     | {
@@ -95,7 +95,7 @@ export class StorageBucketApi {
         { id, name: id, public: options.public },
         { headers: this.headers }
       )
-      return { data: data.name, error: null }
+      return { data, error: null }
     } catch (error) {
       if (isStorageError(error)) {
         return { data: null, error }

--- a/test/storageApi.test.ts
+++ b/test/storageApi.test.ts
@@ -31,7 +31,7 @@ test('Get bucket with wrong id', async () => {
 
 test('create new bucket', async () => {
   const res = await storage.createBucket(newBucketName)
-  expect(res.data).toEqual(newBucketName)
+  expect(res.data?.name).toEqual(newBucketName)
 })
 
 test('create new public bucket', async () => {


### PR DESCRIPTION
instead of cherry picking only name - we still do this in the types though.

also ensures data is always an object.

Fixes [#6](https://github.com/supabase/storage-js/issues/6)