### PR TITLE
fix: metadata type

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,7 +15,7 @@ export interface FileObject {
   updated_at: string
   created_at: string
   last_accessed_at: string
-  metadata: {}
+  metadata: Record<string, any>
   buckets: Bucket
 }
 


### PR DESCRIPTION
Previously accessing metadata.contentType would throw a type error since we set the type to an empty object.