### PR TITLE
fix: only export StorageClient

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,3 @@
-export {
-  StorageClient as StorageClient,
-  StorageClient as SupabaseStorageClient,
-} from './StorageClient'
+export { StorageClient as StorageClient } from './StorageClient'
 export * from './lib/types'
 export * from './lib/errors'


### PR DESCRIPTION
removing the change we added for backward compatibility here https://github.com/supabase/storage-js/issues/46