### PR TITLE
fix: consistent return types for copy

### DIFF
--- a/src/packages/StorageFileApi.ts
+++ b/src/packages/StorageFileApi.ts
@@ -228,7 +228,7 @@ export default class StorageFileApi {
     toPath: string
   ): Promise<
     | {
-        data: { message: string }
+        data: { path: string }
         error: null
       }
     | {
@@ -243,7 +243,7 @@ export default class StorageFileApi {
         { bucketId: this.bucketId, sourceKey: fromPath, destinationKey: toPath },
         { headers: this.headers }
       )
-      return { data, error: null }
+      return { data: { path: data.Key }, error: null }
     } catch (error) {
       if (isStorageError(error)) {
         return { data: null, error }

--- a/test/storageFileApi.test.ts
+++ b/test/storageFileApi.test.ts
@@ -122,10 +122,7 @@ describe('Object API', () => {
       const res = await storage.from(bucketName).copy(uploadPath, newPath)
 
       expect(res.error).toBeNull()
-
-      // TODO: current types are wrong, workaround for now
-      // @ts-ignore
-      expect(res.data?.Key).toEqual(`${bucketName}/${newPath}`)
+      expect(res.data?.path).toEqual(`${bucketName}/${newPath}`)
     })
 
     test('downloads an object', async () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The copy method return signature was incorrect

## What is the new behavior?

we now returns a path key to be consistent with the other methods

