### PR TITLE
feat: download file via url

### DIFF
--- a/src/packages/StorageFileApi.ts
+++ b/src/packages/StorageFileApi.ts
@@ -258,10 +258,12 @@ export default class StorageFileApi {
    *
    * @param path The file path, including the current file name. For example `folder/image.png`.
    * @param expiresIn The number of seconds until the signed URL expires. For example, `60` for a URL which is valid for one minute.
+   * @param options.download triggers the file as a download if set to true. Set this parameter as the name of the file if you want to trigger the download with a different filename.
    */
   async createSignedUrl(
     path: string,
-    expiresIn: number
+    expiresIn: number,
+    options?: { download: string | boolean }
   ): Promise<
     | {
         data: { signedUrl: string }
@@ -280,7 +282,10 @@ export default class StorageFileApi {
         { expiresIn },
         { headers: this.headers }
       )
-      const signedUrl = encodeURI(`${this.url}${data.signedURL}`)
+      const downloadQueryParam = options?.download
+        ? `&download=${options.download === true ? '' : options.download}`
+        : ''
+      const signedUrl = encodeURI(`${this.url}${data.signedURL}${downloadQueryParam}`)
       data = { signedUrl }
       return { data, error: null }
     } catch (error) {
@@ -297,10 +302,12 @@ export default class StorageFileApi {
    *
    * @param paths The file paths to be downloaded, including the current file names. For example `['folder/image.png', 'folder2/image2.png']`.
    * @param expiresIn The number of seconds until the signed URLs expire. For example, `60` for URLs which are valid for one minute.
+   * @param options.download triggers the file as a download if set to true. Set this parameter as the name of the file if you want to trigger the download with a different filename.
    */
   async createSignedUrls(
     paths: string[],
-    expiresIn: number
+    expiresIn: number,
+    options?: { download: string | boolean }
   ): Promise<
     | {
         data: { error: string | null; path: string | null; signedUrl: string }[]
@@ -318,10 +325,16 @@ export default class StorageFileApi {
         { expiresIn, paths },
         { headers: this.headers }
       )
+
+      const downloadQueryParam = options?.download
+        ? `&download=${options.download === true ? '' : options.download}`
+        : ''
       return {
         data: data.map((datum: { signedURL: string }) => ({
           ...datum,
-          signedUrl: datum.signedURL ? encodeURI(`${this.url}${datum.signedURL}`) : null,
+          signedUrl: datum.signedURL
+            ? encodeURI(`${this.url}${datum.signedURL}${downloadQueryParam}`)
+            : null,
         })),
         error: null,
       }
@@ -373,10 +386,20 @@ export default class StorageFileApi {
    * This function does not verify if the bucket is public. If a public URL is created for a bucket which is not public, you will not be able to download the asset.
    *
    * @param path The path and name of the file to generate the public URL for. For example `folder/image.png`.
+   * @param options.download triggers the file as a download if set to true. Set this parameter as the name of the file if you want to trigger the download with a different filename.
    */
-  getPublicUrl(path: string): { data: { publicUrl: string } } {
+  getPublicUrl(
+    path: string,
+    options?: { download: string | boolean }
+  ): { data: { publicUrl: string } } {
     const _path = this._getFinalPath(path)
-    return { data: { publicUrl: encodeURI(`${this.url}/object/public/${_path}`) } }
+    const downloadQueryParam = options?.download
+      ? `?download=${options.download === true ? '' : options.download}`
+      : ''
+
+    return {
+      data: { publicUrl: encodeURI(`${this.url}/object/public/${_path}${downloadQueryParam}`) },
+    }
   }
 
   /**

--- a/test/storageFileApi.test.ts
+++ b/test/storageFileApi.test.ts
@@ -35,12 +35,52 @@ describe('Object API', () => {
       expect(res.data.publicUrl).toEqual(`${URL}/object/public/${bucketName}/${uploadPath}`)
     })
 
+    test('get public URL with download querystring', async () => {
+      const res = storage.from(bucketName).getPublicUrl(uploadPath, {
+        download: true,
+      })
+      expect(res.data.publicUrl).toEqual(
+        `${URL}/object/public/${bucketName}/${uploadPath}?download=`
+      )
+    })
+
+    test('get public URL with custom for download', async () => {
+      const res = storage.from(bucketName).getPublicUrl(uploadPath, {
+        download: 'test.jpg',
+      })
+      expect(res.data.publicUrl).toEqual(
+        `${URL}/object/public/${bucketName}/${uploadPath}?download=test.jpg`
+      )
+    })
+
     test('sign url', async () => {
       await storage.from(bucketName).upload(uploadPath, file)
       const res = await storage.from(bucketName).createSignedUrl(uploadPath, 2000)
 
       expect(res.error).toBeNull()
       expect(res.data?.signedUrl).toContain(`${URL}/object/sign/${bucketName}/${uploadPath}`)
+    })
+
+    test('sign url with download querystring parameter', async () => {
+      await storage.from(bucketName).upload(uploadPath, file)
+      const res = await storage.from(bucketName).createSignedUrl(uploadPath, 2000, {
+        download: true,
+      })
+
+      expect(res.error).toBeNull()
+      expect(res.data?.signedUrl).toContain(`${URL}/object/sign/${bucketName}/${uploadPath}`)
+      expect(res.data?.signedUrl).toContain(`&download=`)
+    })
+
+    test('sign url with custom filename for download', async () => {
+      await storage.from(bucketName).upload(uploadPath, file)
+      const res = await storage.from(bucketName).createSignedUrl(uploadPath, 2000, {
+        download: 'test.jpg',
+      })
+
+      expect(res.error).toBeNull()
+      expect(res.data?.signedUrl).toContain(`${URL}/object/sign/${bucketName}/${uploadPath}`)
+      expect(res.data?.signedUrl).toContain(`&download=test.jpg`)
     })
   })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

## What is the new behavior?

Adds the `download` option to the following methods:

- `getPublicUrl`
- `getSignedUrl`
- `getSignedUrls`

## Additional context

Support downloading a file via url https://github.com/supabase/storage-api/pull/195
