### PR TITLE
refactor: allow download as stream

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,5 @@
+import { StorageError } from './errors'
+
 export type BucketType = 'STANDARD' | 'ANALYTICS'
 
 export interface Bucket {
@@ -164,3 +166,13 @@ type CamelCase<S extends string> = S extends `${infer P1}_${infer P2}${infer P3}
 export type Camelize<T> = {
   [K in keyof T as CamelCase<Extract<K, string>>]: T[K]
 }
+
+export type DownloadResult<T> =
+  | {
+      data: T
+      error: null
+    }
+  | {
+      data: null
+      error: StorageError
+    }

--- a/src/packages/BlobDownloadBuilder.ts
+++ b/src/packages/BlobDownloadBuilder.ts
@@ -1,0 +1,39 @@
+import { isStorageError } from '../lib/errors'
+import { DownloadResult } from '../lib/types'
+import StreamDownloadBuilder from './StreamDownloadBuilder'
+
+export default class BlobDownloadBuilder implements PromiseLike<DownloadResult<Blob>> {
+  constructor(private downloadFn: () => Promise<Response>, private shouldThrowOnError: boolean) {}
+
+  asStream(): StreamDownloadBuilder {
+    return new StreamDownloadBuilder(this.downloadFn, this.shouldThrowOnError)
+  }
+
+  then<TResult1 = DownloadResult<Blob>, TResult2 = never>(
+    onfulfilled?: ((value: DownloadResult<Blob>) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
+  ): Promise<TResult1 | TResult2> {
+    return this.execute().then(onfulfilled, onrejected)
+  }
+
+  private async execute(): Promise<DownloadResult<Blob>> {
+    try {
+      const result = await this.downloadFn()
+
+      return {
+        data: await result.blob(),
+        error: null,
+      }
+    } catch (error) {
+      if (this.shouldThrowOnError) {
+        throw error
+      }
+
+      if (isStorageError(error)) {
+        return { data: null, error }
+      }
+
+      throw error
+    }
+  }
+}

--- a/src/packages/StreamDownloadBuilder.ts
+++ b/src/packages/StreamDownloadBuilder.ts
@@ -1,0 +1,36 @@
+import { isStorageError } from '../lib/errors'
+import { DownloadResult } from '../lib/types'
+
+export default class StreamDownloadBuilder implements PromiseLike<DownloadResult<ReadableStream>> {
+  constructor(private downloadFn: () => Promise<Response>, private shouldThrowOnError: boolean) {}
+
+  then<TResult1 = DownloadResult<ReadableStream>, TResult2 = never>(
+    onfulfilled?:
+      | ((value: DownloadResult<ReadableStream>) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
+  ): Promise<TResult1 | TResult2> {
+    return this.execute().then(onfulfilled, onrejected)
+  }
+
+  private async execute(): Promise<DownloadResult<ReadableStream>> {
+    try {
+      const result = await this.downloadFn()
+
+      return {
+        data: result.body as ReadableStream,
+        error: null,
+      }
+    } catch (error) {
+      if (this.shouldThrowOnError) {
+        throw error
+      }
+
+      if (isStorageError(error)) {
+        return { data: null, error }
+      }
+
+      throw error
+    }
+  }
+}

--- a/test/storageFileApi.test.ts
+++ b/test/storageFileApi.test.ts
@@ -3,9 +3,12 @@ import * as fsp from 'fs/promises'
 import * as fs from 'fs'
 import * as path from 'path'
 import assert from 'assert'
+import ReadableStream from 'node:stream'
 // @ts-ignore
 import fetch, { Response } from '@supabase/node-fetch'
 import { StorageApiError, StorageError } from '../src/lib/errors'
+import BlobDownloadBuilder from '../src/packages/BlobDownloadBuilder'
+import StreamDownloadBuilder from '../src/packages/StreamDownloadBuilder'
 
 // TODO: need to setup storage-api server for this test
 const URL = 'http://localhost:8000/storage/v1'
@@ -408,11 +411,14 @@ describe('Object API', () => {
 
     test('downloads an object', async () => {
       await storage.from(bucketName).upload(uploadPath, file)
-      const res = await storage.from(bucketName).download(uploadPath)
 
-      expect(res.error).toBeNull()
-      expect(res.data?.size).toBeGreaterThan(0)
-      expect(res.data?.type).toEqual('text/plain;charset=utf-8')
+      const blobBuilder = storage.from(bucketName).download(uploadPath)
+      expect(blobBuilder).toBeInstanceOf(BlobDownloadBuilder)
+
+      const blobResponse = await blobBuilder
+      expect(blobResponse.error).toBeNull()
+      expect(blobResponse.data?.size).toBeGreaterThan(0)
+      expect(blobResponse.data?.type).toEqual('text/plain;charset=utf-8')
 
       // throws when .throwOnError is enabled
       await expect(
@@ -422,12 +428,18 @@ describe('Object API', () => {
 
     test('downloads an object as a stream', async () => {
       await storage.from(bucketName).upload(uploadPath, file)
-      const res = await storage.from(bucketName).download(uploadPath, {
-        stream: true,
-      })
 
-      expect(res.error).toBeNull()
-      expect(res.data).toBeInstanceOf(ReadableStream)
+      const streamBuilder = storage.from(bucketName).download(uploadPath).asStream()
+      expect(streamBuilder).toBeInstanceOf(StreamDownloadBuilder)
+
+      const streamResponse = await streamBuilder
+      expect(streamResponse.error).toBeNull()
+      expect(streamResponse.data).toBeInstanceOf(ReadableStream)
+
+      // throws when .throwOnError is enabled
+      await expect(
+        storage.from(bucketName).throwOnError().download('non-existent-file').asStream()
+      ).rejects.toThrow()
     })
 
     test('removes an object', async () => {

--- a/test/storageFileApi.test.ts
+++ b/test/storageFileApi.test.ts
@@ -420,6 +420,16 @@ describe('Object API', () => {
       ).rejects.toThrow()
     })
 
+    test('downloads an object as a stream', async () => {
+      await storage.from(bucketName).upload(uploadPath, file)
+      const res = await storage.from(bucketName).download(uploadPath, {
+        stream: true,
+      })
+
+      expect(res.error).toBeNull()
+      expect(res.data).toBeInstanceOf(ReadableStream)
+    })
+
     test('removes an object', async () => {
       await storage.from(bucketName).upload(uploadPath, file)
       const res = await storage.from(bucketName).remove([uploadPath])


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor? Feature?

## What is the current behavior?

Related to #72 

Right now the library only allows download as `Blob`.

## What is the new behavior?

This PR allows downloading as stream.

The following code is made possible:

```typescript
// Regular download (returns Blob)
const { data: blob } = await storage.from(bucket).download(path)

// Stream download (returns ReadableStream)
const { data: stream } = await storage.from(bucket).download(path).asStream()
```

## Additional context

This is done by returning a class that either implements `PromiseLike<Blob>` or `PromiseLike<ReadableStream>`.

Thus 2 new classes were added.

I have considered adding 1 class only such that there will only be `DownloadBuilder<Blob | ReadableStream>` but it may cause confusion because the following will be possible (core code only for brevity):

```typescript
class DownloadBuilder
{
  private _asStream = false

  asStream() {
    this._asStream = true
    return this
  }

  then() {
    // actual code
  }
}

// nonsensical chaining
const builder = storage.download('file.pdf')
const invalid = await builder.asStream().asStream() // ❌ Should not be possible or otherwise confusing

// mutation confusion
const builder = storage.download('file.pdf')
const invalid = await builder.asStream()
const blob = await builder // ❌ builder has been mutated and the actual response is a stream
```

Alternative approaches considered:

- **Runtime error**: Throw when `asStream()` is called twice → pushes errors to runtime instead of compile-time
- **Return same instance**: Return `this` when already a stream builder → still confusing

Having 2 classes simply makes this impossible to happen.