### PR TITLE
feat: format option for webp support

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -84,5 +84,6 @@ services:
     environment:
       - IMGPROXY_LOCAL_FILESYSTEM_ROOT=/
       - IMGPROXY_USE_ETAG=true
+      - IMGPROXY_ENABLE_WEBP_DETECTION=true
 volumes:
   assets-volume:

--- a/infra/storage/Dockerfile
+++ b/infra/storage/Dockerfile
@@ -1,3 +1,3 @@
-FROM supabase/storage-api:v0.25.1
+FROM supabase/storage-api:v0.27.1
 
 RUN apk add curl --no-cache

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -89,4 +89,11 @@ export interface TransformOptions {
    * Fill resizes the image to fill the entire width and height. If the object's aspect ratio does not match the width and height, the image will be stretched to fit.
    */
   resize?: 'cover' | 'contain' | 'fill'
+  /**
+   * Specify the format of the image requested.
+   *
+   * When using 'origin' we force the format to be the same as the original image,
+   * bypassing automatic browser optimisation such as webp conversion
+   */
+  format?: 'origin'
 }

--- a/src/packages/StorageFileApi.ts
+++ b/src/packages/StorageFileApi.ts
@@ -593,6 +593,10 @@ export default class StorageFileApi {
       params.push(`resize=${transform.resize}`)
     }
 
+    if (transform.format) {
+      params.push(`format=${transform.format}`)
+    }
+
     return params.join('&')
   }
 }

--- a/test/storageFileApi.test.ts
+++ b/test/storageFileApi.test.ts
@@ -248,6 +248,47 @@ describe('Object API', () => {
     })
   })
 
+  it('will return the image as webp when the browser support it', async () => {
+    const storage = new StorageClient(URL, { Authorization: `Bearer ${KEY}`, Accept: 'image/webp' })
+    const privateBucketName = 'my-private-bucket'
+    await findOrCreateBucket(privateBucketName)
+
+    const { error: uploadError } = await storage.from(privateBucketName).upload(uploadPath, file)
+    expect(uploadError).toBeNull()
+
+    const res = await storage.from(privateBucketName).download(uploadPath, {
+      transform: {
+        width: 200,
+        height: 200,
+      },
+    })
+
+    expect(res.error).toBeNull()
+    expect(res.data?.size).toBeGreaterThan(0)
+    expect(res.data?.type).toEqual('image/webp')
+  })
+
+  it('will return the original image format when format is origin', async () => {
+    const storage = new StorageClient(URL, { Authorization: `Bearer ${KEY}`, Accept: 'image/webp' })
+    const privateBucketName = 'my-private-bucket'
+    await findOrCreateBucket(privateBucketName)
+
+    const { error: uploadError } = await storage.from(privateBucketName).upload(uploadPath, file)
+    expect(uploadError).toBeNull()
+
+    const res = await storage.from(privateBucketName).download(uploadPath, {
+      transform: {
+        width: 200,
+        height: 200,
+        format: 'origin',
+      },
+    })
+
+    expect(res.error).toBeNull()
+    expect(res.data?.size).toBeGreaterThan(0)
+    expect(res.data?.type).toEqual('image/jpeg')
+  })
+
   it('will get a signed transformed image', async () => {
     await storage.from(bucketName).upload(uploadPath, file)
     const res = await storage.from(bucketName).createSignedUrl(uploadPath, 60000, {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the new behavior?

Introduced a `format` option to request the image in a different format.
Currently, the only value allowed is `origin` which will force the image to be returned with its original format.
If not provided we will automatically optimise the image using webp

## Additional context

```ts
await storage.from('bucket').download(uploadPath, {
      transform: {
        width: 200,
        height: 200,
        format: 'origin',
      },
    })
```
