### PR TITLE
Update upload methods to allow duplex option to be passed in

### DIFF
--- a/src/packages/StorageFileApi.ts
+++ b/src/packages/StorageFileApi.ts
@@ -101,6 +101,7 @@ export default class StorageFileApi {
         method,
         body: body as BodyInit,
         headers,
+        ...(options?.duplex ? { duplex: options.duplex } : {})
       })
 
       if (res.ok) {


### PR DESCRIPTION
Undici >v5.12.0 requires this.

## What kind of change does this PR introduce?

bug fix

## What is the current behavior?

https://github.com/supabase/storage-js/issues/146

## What is the new behavior?

Allows the following to go through to the request
```js
await supabase.storage.from('some-bucket').upload('filename', someReadableStream, { duplex: 'half' })
```
