### PR TITLE
fix: unhandled promise error when response has invalid json format

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -26,7 +26,7 @@ const handleError = async (error: unknown, reject: (reason?: any) => void) => {
         reject(new StorageApiError(_getErrorMessage(err), error.status || 500))
       })
       .catch((err) => {
-        reject(new StorageApiError(_getErrorMessage(err), error.status || 500))
+        reject(new StorageUnknownError(_getErrorMessage(err), err))
       })
   } else {
     reject(new StorageUnknownError(_getErrorMessage(error), error))

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -20,9 +20,14 @@ const handleError = async (error: unknown, reject: (reason?: any) => void) => {
   const Res = await resolveResponse()
 
   if (error instanceof Res) {
-    error.json().then((err) => {
-      reject(new StorageApiError(_getErrorMessage(err), error.status || 500))
-    })
+    error
+      .json()
+      .then((err) => {
+        reject(new StorageApiError(_getErrorMessage(err), error.status || 500))
+      })
+      .catch((err) => {
+        reject(new StorageApiError(_getErrorMessage(err), error.status || 500))
+      })
   } else {
     reject(new StorageUnknownError(_getErrorMessage(error), error))
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

on `handleError` method, we call error.json() without a catch block. It can end up with an unhandled promise error. This kind of error can kill a Nodejs application 

## What is the new behavior?

add catch block and reject with a StorageUnknownError

