### PR TITLE
feat: custom file size limit and mime types at bucket level

### DIFF
--- a/infra/storage/Dockerfile
+++ b/infra/storage/Dockerfile
@@ -1,3 +1,3 @@
-FROM supabase/storage-api:v0.28.0
+FROM supabase/storage-api:v0.29.1
 
 RUN apk add curl --no-cache

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,6 +2,8 @@ export interface Bucket {
   id: string
   name: string
   owner: string
+  file_size_limit?: number
+  allowed_mime_types?: string[]
   created_at: string
   updated_at: string
   public: boolean

--- a/src/packages/StorageBucketApi.ts
+++ b/src/packages/StorageBucketApi.ts
@@ -74,11 +74,15 @@ export default class StorageBucketApi {
    *
    * @param id A unique identifier for the bucket you are creating.
    * @param options.public The visibility of the bucket. Public buckets don't require an authorization token to download objects, but still require a valid token for all other operations. By default, buckets are private.
+   * @param options.fileSizeLimit specifies the file size limit that this bucket can accept during upload
+   * @param options.allowedMimeTypes specifies the allowed mime types that this bucket can accept during upload
    * @returns newly created bucket id
    */
   async createBucket(
     id: string,
-    options: { public: boolean } = { public: false }
+    options: { public: boolean; fileSizeLimit?: number | string; allowedMimeTypes?: string[] } = {
+      public: false,
+    }
   ): Promise<
     | {
         data: Pick<Bucket, 'name'>
@@ -93,7 +97,13 @@ export default class StorageBucketApi {
       const data = await post(
         this.fetch,
         `${this.url}/bucket`,
-        { id, name: id, public: options.public },
+        {
+          id,
+          name: id,
+          public: options.public,
+          file_size_limit: options.fileSizeLimit,
+          allowed_mime_types: options.allowedMimeTypes,
+        },
         { headers: this.headers }
       )
       return { data, error: null }
@@ -111,10 +121,12 @@ export default class StorageBucketApi {
    *
    * @param id A unique identifier for the bucket you are updating.
    * @param options.public The visibility of the bucket. Public buckets don't require an authorization token to download objects, but still require a valid token for all other operations.
+   * @param options.fileSizeLimit specifies the file size limit that this bucket can accept during upload
+   * @param options.allowedMimeTypes specifies the allowed mime types that this bucket can accept during upload
    */
   async updateBucket(
     id: string,
-    options: { public: boolean }
+    options: { public: boolean; fileSizeLimit?: number | string; allowedMimeTypes?: string[] }
   ): Promise<
     | {
         data: { message: string }
@@ -129,7 +141,13 @@ export default class StorageBucketApi {
       const data = await put(
         this.fetch,
         `${this.url}/bucket/${id}`,
-        { id, name: id, public: options.public },
+        {
+          id,
+          name: id,
+          public: options.public,
+          file_size_limit: options.fileSizeLimit,
+          allowed_mime_types: options.allowedMimeTypes,
+        },
         { headers: this.headers }
       )
       return { data, error: null }

--- a/test/__snapshots__/storageApi.test.ts.snap
+++ b/test/__snapshots__/storageApi.test.ts.snap
@@ -2,7 +2,9 @@
 
 exports[`bucket api Get bucket by id 1`] = `
 Object {
+  "allowed_mime_types": null,
   "created_at": "2021-02-17T04:43:32.770206+00:00",
+  "file_size_limit": 0,
   "id": "bucket2",
   "name": "bucket2",
   "owner": "4d56e902-f0a0-4662-8448-a4d9e643c142",
@@ -22,6 +24,12 @@ Object {
 exports[`bucket api empty bucket 1`] = `
 Object {
   "message": "Successfully emptied",
+}
+`;
+
+exports[`bucket api partially update bucket 1`] = `
+Object {
+  "message": "Successfully updated",
 }
 `;
 

--- a/test/storageApi.test.ts
+++ b/test/storageApi.test.ts
@@ -42,11 +42,35 @@ describe('bucket api', () => {
   })
 
   test('update bucket', async () => {
-    const updateRes = await storage.updateBucket(newBucketName, { public: true })
+    const newBucketName = `my-new-bucket-${Date.now()}`
+    await storage.createBucket(newBucketName)
+    const updateRes = await storage.updateBucket(newBucketName, {
+      public: true,
+      fileSizeLimit: '20mb',
+      allowedMimeTypes: ['image/jpeg'],
+    })
     expect(updateRes.error).toBeNull()
     expect(updateRes.data).toMatchSnapshot()
     const getRes = await storage.getBucket(newBucketName)
     expect(getRes.data!.public).toBe(true)
+    expect(getRes.data!.file_size_limit).toBe(20000000)
+    expect(getRes.data!.allowed_mime_types).toEqual(['image/jpeg'])
+  })
+
+  test('partially update bucket', async () => {
+    const newBucketName = `my-new-bucket-${Date.now()}`
+    await storage.createBucket(newBucketName, {
+      public: true,
+      fileSizeLimit: '20mb',
+      allowedMimeTypes: ['image/jpeg'],
+    })
+    const updateRes = await storage.updateBucket(newBucketName, { public: false })
+    expect(updateRes.error).toBeNull()
+    expect(updateRes.data).toMatchSnapshot()
+    const getRes = await storage.getBucket(newBucketName)
+    expect(getRes.data!.public).toBe(false)
+    expect(getRes.data!.file_size_limit).toBe(20000000)
+    expect(getRes.data!.allowed_mime_types).toEqual(['image/jpeg'])
   })
 
   test('empty bucket', async () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature


## What is the new behavior?

It is now possible to specify, `file_size_limit` and `allowed_mime_types` when creating a bucket.
These limits will be imposed during the upload of an asset, allowing you to validate server side the values

Example:

```ts

// Create Bucket with file size limit 20mb
await storage.createBucket('bucket-name', {
      public: true,
      fileSizeLimit: '20mb',
      allowedMimeTypes: ['image/jpeg'],
})

// load the file
const bigFile = ... // 1GB

// Upload
const res = await storage.from('bucket-name').upload(bigFile, {
   contentType: 'image/jpeg',
})

// Response
expect(res.error).toEqual({
   error: 'Payload too large',
   message: 'The object exceeded the maximum allowed size',
   statusCode: '413',
})
```
