### PR TITLE
Fix typescript interface `FileOptions` does not have `duplex`

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -37,6 +37,10 @@ export interface FileOptions {
    * When upsert is set to true, the file is overwritten if it exists. When set to false, an error is thrown if the object already exists. Defaults to false.
    */
   upsert?: boolean
+  /**
+   * The duplex option is a string parameter that enables or disables duplex streaming, allowing for both reading and writing data in the same stream. It can be passed as an option to the fetch() method.
+   */
+  duplex?: string
 }
 
 export interface SearchOptions {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

With #147 PR merged. There is no `duplex` key available in `FileOptions` and still being accessed. Which is failing unit tests. And also not allowing to pass `duplex` in typescript projects.

## What is the new behavior?

This PR included `duplex` parameter in `FileOptions` interface.

## Additional context

Add any other context or screenshots.
Before
<img width="299" alt="Screenshot 2023-04-03 at 11 41 25 PM" src="https://user-images.githubusercontent.com/20799038/229592134-8a071226-645c-4217-b59a-b25528856325.png">

After
<img width="293" alt="Screenshot 2023-04-03 at 11 41 58 PM" src="https://user-images.githubusercontent.com/20799038/229592226-09707fa6-ba94-4c3a-bd69-ef353ea21702.png">
