### PR TITLE
fix: allow null on bucket constraints

### DIFF
--- a/src/packages/StorageBucketApi.ts
+++ b/src/packages/StorageBucketApi.ts
@@ -74,13 +74,17 @@ export default class StorageBucketApi {
    *
    * @param id A unique identifier for the bucket you are creating.
    * @param options.public The visibility of the bucket. Public buckets don't require an authorization token to download objects, but still require a valid token for all other operations. By default, buckets are private.
-   * @param options.fileSizeLimit specifies the file size limit that this bucket can accept during upload
-   * @param options.allowedMimeTypes specifies the allowed mime types that this bucket can accept during upload
+   * @param options.fileSizeLimit specifies the file size limit that this bucket can accept during upload, pass null to remove the constraint
+   * @param options.allowedMimeTypes specifies the allowed mime types that this bucket can accept during upload, pass null to remove the constraint
    * @returns newly created bucket id
    */
   async createBucket(
     id: string,
-    options: { public: boolean; fileSizeLimit?: number | string; allowedMimeTypes?: string[] } = {
+    options: {
+      public: boolean
+      fileSizeLimit?: number | string | null
+      allowedMimeTypes?: string[] | null
+    } = {
       public: false,
     }
   ): Promise<
@@ -121,12 +125,16 @@ export default class StorageBucketApi {
    *
    * @param id A unique identifier for the bucket you are updating.
    * @param options.public The visibility of the bucket. Public buckets don't require an authorization token to download objects, but still require a valid token for all other operations.
-   * @param options.fileSizeLimit specifies the file size limit that this bucket can accept during upload
-   * @param options.allowedMimeTypes specifies the allowed mime types that this bucket can accept during upload
+   * @param options.fileSizeLimit specifies the file size limit that this bucket can accept during upload, pass null to remove the constraint
+   * @param options.allowedMimeTypes specifies the allowed mime types that this bucket can accept during upload, pass null to remove the constraint
    */
   async updateBucket(
     id: string,
-    options: { public: boolean; fileSizeLimit?: number | string; allowedMimeTypes?: string[] }
+    options: {
+      public: boolean
+      fileSizeLimit?: number | string | null
+      allowedMimeTypes?: string[] | null
+    }
   ): Promise<
     | {
         data: { message: string }

--- a/src/packages/StorageBucketApi.ts
+++ b/src/packages/StorageBucketApi.ts
@@ -74,8 +74,12 @@ export default class StorageBucketApi {
    *
    * @param id A unique identifier for the bucket you are creating.
    * @param options.public The visibility of the bucket. Public buckets don't require an authorization token to download objects, but still require a valid token for all other operations. By default, buckets are private.
-   * @param options.fileSizeLimit specifies the file size limit that this bucket can accept during upload, pass null to remove the constraint
-   * @param options.allowedMimeTypes specifies the allowed mime types that this bucket can accept during upload, pass null to remove the constraint
+   * @param options.fileSizeLimit specifies the max file size in bytes that can be uploaded to this bucket.
+   * The global file size limit takes precedence over this value.
+   * The default value is null, which doesn't set a per bucket file size limit.
+   * @param options.allowedMimeTypes specifies the allowed mime types that this bucket can accept during upload.
+   * The default value is null, which allows files with all mime types to be uploaded.
+   * Each mime type specified can be a wildcard, e.g. image/*, or a specific mime type, e.g. image/png.
    * @returns newly created bucket id
    */
   async createBucket(
@@ -125,8 +129,12 @@ export default class StorageBucketApi {
    *
    * @param id A unique identifier for the bucket you are updating.
    * @param options.public The visibility of the bucket. Public buckets don't require an authorization token to download objects, but still require a valid token for all other operations.
-   * @param options.fileSizeLimit specifies the file size limit that this bucket can accept during upload, pass null to remove the constraint
-   * @param options.allowedMimeTypes specifies the allowed mime types that this bucket can accept during upload, pass null to remove the constraint
+   * @param options.fileSizeLimit specifies the max file size in bytes that can be uploaded to this bucket.
+   * The global file size limit takes precedence over this value.
+   * The default value is null, which doesn't set a per bucket file size limit.
+   * @param options.allowedMimeTypes specifies the allowed mime types that this bucket can accept during upload.
+   * The default value is null, which allows files with all mime types to be uploaded.
+   * Each mime type specified can be a wildcard, e.g. image/*, or a specific mime type, e.g. image/png.
    */
   async updateBucket(
     id: string,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Pass `null` to `fileSizeLimit`, `allowedMimeTypes` to remove the constraint

