### PR TITLE
docs: signed upload url expiry time

### DIFF
--- a/src/packages/StorageFileApi.ts
+++ b/src/packages/StorageFileApi.ts
@@ -213,7 +213,7 @@ export default class StorageFileApi {
   /**
    * Creates a signed upload URL.
    * Signed upload URLs can be used to upload files to the bucket without further authentication.
-   * They are valid for one minute.
+   * They are valid for 2 hours.
    * @param path The file path, including the current file name. For example `folder/image.png`.
    */
   async createSignedUploadUrl(


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the new behavior?

Bump signed URL expiry to 2h
