### PR TITLE
Return ID and full path of uploaded file

### DIFF
--- a/src/packages/StorageFileApi.ts
+++ b/src/packages/StorageFileApi.ts
@@ -194,13 +194,15 @@ export default class StorageFileApi {
         headers,
       })
 
+      const data = await res.json()
+
       if (res.ok) {
         return {
-          data: { path: cleanPath },
+          data: { path: cleanPath, fullPath: data.Key },
           error: null,
         }
       } else {
-        const error = await res.json()
+        const error = data
         return { data: null, error }
       }
     } catch (error) {

--- a/src/packages/StorageFileApi.ts
+++ b/src/packages/StorageFileApi.ts
@@ -68,7 +68,7 @@ export default class StorageFileApi {
     fileOptions?: FileOptions
   ): Promise<
     | {
-        data: { path: string }
+        data: { id: string, path: string, fullPath: string }
         error: null
       }
     | {
@@ -106,13 +106,15 @@ export default class StorageFileApi {
         ...(options?.duplex ? { duplex: options.duplex } : {}),
       })
 
+      const data = await res.json()
+
       if (res.ok) {
         return {
-          data: { path: cleanPath },
+          data: { path: cleanPath, id: data.Id, fullPath: data.Key },
           error: null,
         }
       } else {
-        const error = await res.json()
+        const error = data
         return { data: null, error }
       }
     } catch (error) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for #170 

## What is the current behavior?

Currently, only part of the path (not including the bucket) of the uploaded file is returned even though the API returns both the ID and full path of the file: [source](https://supabase.github.io/storage-api/#/object/post_object__bucketName___wildcard_)

## What is the new behavior?

The new behavior is for the response of the upload client call to return the id and full path in addition to the path.