### PR TITLE
feat: always consume to prevent resource leaks

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -60,14 +60,15 @@ async function _handleRequest(
 ): Promise<any> {
   return new Promise((resolve, reject) => {
     fetcher(url, _getRequestParams(method, options, parameters, body))
-      .then((result) => {
-        if (!result.ok) throw result
-        if (options?.noResolveJson) return result
-        return result.json()
+      .then(async (result) => {
+        const body = await result.text();
+        if (!result.ok) throw result;
+        if (options?.noResolveJson) return result;
+        return JSON.parse(body);
       })
       .then((data) => resolve(data))
-      .catch((error) => handleError(error, reject))
-  })
+      .catch((error) => handleError(error, reject));
+  });
 }
 
 export async function get(


### PR DESCRIPTION
## What kind of change does this PR introduce?

We get resource leaks because in the `_handleRequest` function, a fetch request is made and its response is thrown if it's not ok. 

## What is the current behavior?

If the noResolveJson option is not set, it returns the JSON body of the response (return result.json()). But in case an error occurs (the response is not ok) or the noResolveJson option is set, the function just throws or returns the response without consuming its body. 

## What is the new behavior?

It will always consume the response to prevent leaks. 

## Additional context

Add any other context or screenshots.
