### PR TITLE
add id and fullPath to update and upload functions response

### DIFF
--- a/src/packages/StorageFileApi.ts
+++ b/src/packages/StorageFileApi.ts
@@ -138,7 +138,7 @@ export default class StorageFileApi {
     fileOptions?: FileOptions
   ): Promise<
     | {
-        data: { path: string }
+        data: { id: string, path: string, fullPath: string }
         error: null
       }
     | {
@@ -282,7 +282,7 @@ export default class StorageFileApi {
     fileOptions?: FileOptions
   ): Promise<
     | {
-        data: { path: string }
+        data: { id: string, path: string, fullPath: string }
         error: null
       }
     | {


### PR DESCRIPTION
Update return interface in upload and update functions StorageFileApi.ts to return id and fullPath since the uploadOrUpdate returns fullPath and id which are used in multiple cases when uploading/updating a file

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

the id and full path are not returned in the upload and update functions in StorageFileApi.ts

## What is the new behavior?

the id and full path are returned in the upload and update functions in StorageFileApi.ts

