### PR TITLE
Exact optional property types

### DIFF
--- a/src/packages/StorageFileApi.ts
+++ b/src/packages/StorageFileApi.ts
@@ -40,7 +40,7 @@ type FileBody =
 export default class StorageFileApi {
   protected url: string
   protected headers: { [key: string]: string }
-  protected bucketId?: string
+  protected bucketId: string | undefined
   protected fetch: Fetch
 
   constructor(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "target": "ES6",
 
     "strict": true,
+    "exactOptionalPropertyTypes": true,
 
     "esModuleInterop": true,
     "moduleResolution": "Node",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix and TS config update

## What is the current behavior?

The `StorageFileApi.bucketId` field type is `bucketId?: string`, which breaks when `exactOptionalPropertyTypes` is on. This causes headaches for folks trying to use the library with the flag on.

## What is the new behavior?

1. Fixed `StorageFileApi.bucketId` field type: `bucketId: string | undefined`
2. Enabled `"exactOptionalPropertyTypes": true` in TS config

Now it should play nice with the flag on without breaking existing setups.

## Additional context

Here's why I think this change is useful:

- TypeScript itself [recommends using this flag](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes). The reason it is not in `strict` is just to avoid breaking too much existing user code.
    
- Right now, anyone with this flag on can't use the library without it failing to compile. Using `skipLibCheck` isn't great because it skips all `.d.ts` files, including user-made ones (see [this issue](https://github.com/sindresorhus/tsconfig/issues/15)).
    
- Except for the one field I fixed, the package already follows this rule.
    
- In my current project with 58 libraries, this is the only one that breaks with the flag on, indicating it's already a standard in the ecosystem.
    
These tweaks should make the library more robust and play better with strict TS setups, without causing issues for current users. Let me know if you need any more info!