### PR TITLE
feat: custom-metadata, exists, info methods

### DIFF
--- a/infra/storage/Dockerfile
+++ b/infra/storage/Dockerfile
@@ -1,3 +1,3 @@
-FROM supabase/storage-api:v1.2.1
+FROM supabase/storage-api:v1.8.2
 
 RUN apk add curl --no-cache

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -21,3 +21,19 @@ export const resolveResponse = async (): Promise<typeof Response> => {
 
   return Response
 }
+
+export const recursiveToCamel = (item: Record<string, any>): unknown => {
+  if (Array.isArray(item)) {
+    return item.map((el) => recursiveToCamel(el))
+  } else if (typeof item === 'function' || item !== Object(item)) {
+    return item
+  }
+
+  const result: Record<string, any> = {}
+  Object.entries(item).forEach(([key, value]) => {
+    const newKey = key.replace(/([-_][a-z])/gi, (c) => c.toUpperCase().replace(/[-_]/g, ''))
+    result[newKey] = recursiveToCamel(value)
+  })
+
+  return result
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -21,6 +21,22 @@ export interface FileObject {
   buckets: Bucket
 }
 
+export interface FileObjectV2 {
+  id: string
+  version: string
+  name: string
+  bucket_id: string
+  updated_at: string
+  created_at: string
+  last_accessed_at: string
+  size?: number
+  cache_control?: string
+  content_type?: string
+  etag?: string
+  last_modified?: string
+  metadata?: Record<string, any>
+}
+
 export interface SortBy {
   column?: string
   order?: string
@@ -43,6 +59,16 @@ export interface FileOptions {
    * The duplex option is a string parameter that enables or disables duplex streaming, allowing for both reading and writing data in the same stream. It can be passed as an option to the fetch() method.
    */
   duplex?: string
+
+  /**
+   * The metadata option is an object that allows you to store additional information about the file. This information can be used to filter and search for files. The metadata object can contain any key-value pairs you want to store.
+   */
+  metadata?: Record<string, any>
+
+  /**
+   * Optionally add extra headers
+   */
+  headers?: Record<string, string>
 }
 
 export interface DestinationOptions {
@@ -112,4 +138,12 @@ export interface TransformOptions {
    * When this option is not passed in, images are optimized to modern image formats like Webp.
    */
   format?: 'origin'
+}
+
+type CamelCase<S extends string> = S extends `${infer P1}_${infer P2}${infer P3}`
+  ? `${Lowercase<P1>}${Uppercase<P2>}${CamelCase<P3>}`
+  : S
+
+export type Camelize<T> = {
+  [K in keyof T as CamelCase<Extract<K, string>>]: T[K]
 }

--- a/test/storageFileApi.test.ts
+++ b/test/storageFileApi.test.ts
@@ -163,6 +163,25 @@ describe('Object API', () => {
       expect(updateRes.data?.path).toEqual(uploadPath)
     })
 
+    test('can upload with custom metadata', async () => {
+      const res = await storage.from(bucketName).upload(uploadPath, file, {
+        metadata: {
+          custom: 'metadata',
+          second: 'second',
+          third: 'third',
+        },
+      })
+      expect(res.error).toBeNull()
+
+      const updateRes = await storage.from(bucketName).info(uploadPath)
+      expect(updateRes.error).toBeNull()
+      expect(updateRes.data?.metadata).toEqual({
+        custom: 'metadata',
+        second: 'second',
+        third: 'third',
+      })
+    })
+
     test('can upload a file within the file size limit', async () => {
       const bucketName = 'with-limit' + Date.now()
       await storage.createBucket(bucketName, {
@@ -367,6 +386,38 @@ describe('Object API', () => {
           name: uploadPath,
         }),
       ])
+    })
+
+    test('get object info', async () => {
+      await storage.from(bucketName).upload(uploadPath, file)
+      const res = await storage.from(bucketName).info(uploadPath)
+
+      expect(res.error).toBeNull()
+      expect(res.data).toEqual(
+        expect.objectContaining({
+          id: expect.any(String),
+          name: expect.any(String),
+          createdAt: expect.any(String),
+          cacheControl: expect.any(String),
+          size: expect.any(Number),
+          etag: expect.any(String),
+          lastModified: expect.any(String),
+          contentType: expect.any(String),
+          metadata: {},
+          version: expect.any(String),
+        })
+      )
+    })
+
+    test('check if object exists', async () => {
+      await storage.from(bucketName).upload(uploadPath, file)
+      const res = await storage.from(bucketName).exists(uploadPath)
+
+      expect(res.error).toBeNull()
+      expect(res.data).toEqual(true)
+
+      const resNotExists = await storage.from(bucketName).exists('do-not-exists')
+      expect(resNotExists.data).toEqual(false)
     })
   })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the new behavior?

### Custom Metadata
Adds support for custom metadata on objects:

```ts
const res = await storage.from(bucketName).upload(uploadPath, file, {
        metadata: {
          custom: 'metadata',
          second: 'second',
          third: 'third',
        },
})
```

### Exists / Info

added 2 new methods, exists and info

**Info**
fetches the information about this object

```ts
const {data: obj} = await storage.from(bucketName).info(uploadPath)

obj.id
obj.metadata
```

**Exists**
Check if a file exists

```ts
const {data: exists} = await storage.from(bucketName).exists(uploadPath)

console.log(exists) // true / false
```

Relates to https://github.com/supabase/storage/issues/439
