### PR TITLE
feat: add private method to get expected content type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@types/jest": "^26.0.13",
+        "@types/mime-types": "2.1.4",
         "form-data": "^4.0.0",
         "genversion": "^3.0.1",
         "husky": "^4.3.0",
@@ -1313,6 +1314,12 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "node_modules/@types/mime-types": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
+      "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
       "dev": true
     },
     "node_modules/@types/minimatch": {
@@ -7934,6 +7941,12 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "@types/mime-types": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
+      "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
       "dev": true
     },
     "@types/minimatch": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.13",
+    "@types/mime-types": "2.1.4",
     "form-data": "^4.0.0",
     "genversion": "^3.0.1",
     "husky": "^4.3.0",

--- a/src/packages/StorageFileApi.ts
+++ b/src/packages/StorageFileApi.ts
@@ -180,9 +180,7 @@ export default class StorageFileApi {
       md: 'text/markdown',
     }
 
-    return extension
-      ? mimeTypes[extension] || 'application/octet-stream'
-      : 'application/octet-stream'
+    return extension ? mimeTypes[extension] : 'application/octet-stream'
   }
 
   /**

--- a/src/packages/StorageFileApi.ts
+++ b/src/packages/StorageFileApi.ts
@@ -180,7 +180,7 @@ export default class StorageFileApi {
       md: 'text/markdown',
     }
 
-    return extension ? mimeTypes[extension] : 'application/octet-stream'
+    return extension && mimeTypes[extension] ? mimeTypes[extension] : ''
   }
 
   /**

--- a/src/packages/StorageFileApi.ts
+++ b/src/packages/StorageFileApi.ts
@@ -1,6 +1,7 @@
 import { isStorageError, StorageError, StorageUnknownError } from '../lib/errors'
 import { Fetch, get, head, post, remove } from '../lib/fetch'
 import { recursiveToCamel, resolveFetch } from '../lib/helpers'
+import { lookup } from 'mime-types'
 import {
   FileObject,
   FileOptions,
@@ -170,17 +171,9 @@ export default class StorageFileApi {
   }
 
   private _getExpectedContentType(path: string): string {
-    const extension = path.split('.').pop()?.toLowerCase()
-    const mimeTypes: { [key: string]: string } = {
-      png: 'image/png',
-      jpg: 'image/jpeg',
-      jpeg: 'image/jpeg',
-      gif: 'image/gif',
-      pdf: 'application/pdf',
-      md: 'text/markdown',
-    }
-
-    return extension && mimeTypes[extension] ? mimeTypes[extension] : ''
+    const extension = path.split('.').pop() || ''
+    const mimeType = lookup(extension)
+    return mimeType || ''
   }
 
   /**


### PR DESCRIPTION
## What kind of change does this PR introduce?
Related to issue: https://github.com/supabase/supabase-js/issues/1248

This PR expands MIME type support in the `_getExpectedContentType` function and adds MIME type validation during upload.

## What is the current behavior?

`createSignedUploadUrl` does not validate MIME types.

## What is the new behavior?

- Added more MIME types to the `_getExpectedContentType` function for broader file type support.
- Implemented a check to compare the expected MIME type with the actual Content-Type during upload, throwing an error if they don't match.

## Additional context

- The selection of additional MIME types was done arbitrarily. If support for more file types is needed, I'm open to suggestions and can expand the list accordingly.
- Currently, the function throws a StorageError when the content type doesn't match. I'm seeking feedback on whether using console.warn for a warning instead would be more appropriate.