### PR TITLE
fix: StorageError shape to match returned errors from API

### DIFF
--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -12,19 +12,19 @@ export function isStorageError(error: unknown): error is StorageError {
 }
 
 export class StorageApiError extends StorageError {
-  status: number
+  statusCode: string
 
-  constructor(message: string, status: number) {
+  constructor(message: string, statusCode: string) {
     super(message)
     this.name = 'StorageApiError'
-    this.status = status
+    this.statusCode = statusCode
   }
 
   toJSON() {
     return {
       name: this.name,
       message: this.message,
-      status: this.status,
+      statusCode: this.statusCode,
     }
   }
 }

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -27,7 +27,7 @@ const handleError = async (
     error
       .json()
       .then((err) => {
-        reject(new StorageApiError(_getErrorMessage(err), error.status || 500))
+        reject(new StorageApiError(_getErrorMessage(err), error.status.toString() || '500'))
       })
       .catch((err) => {
         reject(new StorageUnknownError(_getErrorMessage(err), err))


### PR DESCRIPTION
## What kind of change does this PR introduce?
#165

## What is the current behavior?
The [StorageApiError class defined in storage-js](https://github.com/supabase/storage-js/blob/b2e3486222126620cc65a5a1c1f967d25b4fb099/src/lib/errors.ts#L14) has a status field.
The [StorageError defined in storage-api](https://github.com/supabase/storage-api/blob/1794d04ab0e7259d9058293e257f442015252ec3/src/storage/errors.ts#LL4C1-L4C1) has a statusCode field.

This mismatch make it difficult to correctly handle errors on the frontend.
I'd like to use the isStorageError function defined in storage-js, but it does not recognize errors thrown from the API

## What is the new behavior?
Update `StorageApiError` class and error handling to match API returned errors

* Change `StorageApiError` class in `src/lib/errors.ts` to have a `statusCode` field instead of `status`
* Update `toJSON` method in `StorageApiError` class to return `statusCode` instead of `status`
* Modify `handleError` function in `src/lib/fetch.ts` to handle `statusCode` instead of `status`

## Additional context
Supabase Storage API scheme
https://supabase.github.io/storage/
```
errorScheme {
  statusCode*	string
  error*	string
  message*	string
}
```
