### PR TITLE
fix: type of params array to accept strings

### DIFF
--- a/src/packages/StorageFileApi.ts
+++ b/src/packages/StorageFileApi.ts
@@ -626,7 +626,7 @@ export default class StorageFileApi {
     options?: { download?: string | boolean; transform?: TransformOptions }
   ): { data: { publicUrl: string } } {
     const _path = this._getFinalPath(path)
-    const _queryString = []
+    const _queryString: string[] = []
 
     const downloadQueryParam = options?.download
       ? `download=${options.download === true ? '' : options.download}`
@@ -808,7 +808,7 @@ export default class StorageFileApi {
   }
 
   private transformOptsToQueryString(transform: TransformOptions) {
-    const params = []
+    const params: string[] = []
     if (transform.width) {
       params.push(`width=${transform.width}`)
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

type fix

## What is the current behavior?

Just a type error.

## What is the new behavior?

No type error 👍.

## Additional context

const _queryString after:

![Screenshot_12](https://github.com/user-attachments/assets/c4944707-65a0-4e71-81cc-1513f0ac1cb3)

const _queryString before:

![Screenshot_13](https://github.com/user-attachments/assets/89767502-704e-49d8-bf65-0d742de6676d)

const params after:

![Screenshot_15](https://github.com/user-attachments/assets/014a596f-686c-4432-8831-cf91f461454e)

const params before:

![Screenshot_16](https://github.com/user-attachments/assets/6f2291e8-baff-404e-bebf-c2eb72bb0cff)
