### PR TITLE
fix: Properly handle errors in Upload Api  (related to StorageError)

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -45,15 +45,17 @@ const _getRequestParams = (
 ) => {
   const params: { [k: string]: any } = { method, headers: options?.headers || {} }
 
-  if (method === 'GET') {
+  if (method === 'GET' || !body) {
     return params
   }
 
-  params.headers = { 'Content-Type': 'application/json', ...options?.headers }
-
-  if (body) {
+  if (body instanceof FormData) {
+    params.body = body
+  } else {
+    params.headers = { 'Content-Type': 'application/json', ...options?.headers }
     params.body = JSON.stringify(body)
   }
+
   return { ...params, ...parameters }
 }
 

--- a/src/packages/StorageFileApi.ts
+++ b/src/packages/StorageFileApi.ts
@@ -1,5 +1,5 @@
 import { isStorageError, StorageError, StorageUnknownError } from '../lib/errors'
-import { Fetch, get, head, post, remove } from '../lib/fetch'
+import { Fetch, get, head, post, put, remove } from '../lib/fetch'
 import { recursiveToCamel, resolveFetch } from '../lib/helpers'
 import {
   FileObject,
@@ -118,23 +118,16 @@ export default class StorageFileApi {
 
       const cleanPath = this._removeEmptyFolders(path)
       const _path = this._getFinalPath(cleanPath)
-      const res = await this.fetch(`${this.url}/object/${_path}`, {
-        method,
-        body: body as BodyInit,
-        headers,
-        ...(options?.duplex ? { duplex: options.duplex } : {}),
-      })
+      const data = await (method == 'PUT' ? put : post)(
+        this.fetch,
+        `${this.url}/object/${_path}`,
+        body,
+        { headers, ...(options?.duplex ? { duplex: options.duplex } : {}) }
+      )
 
-      const data = await res.json()
-
-      if (res.ok) {
-        return {
-          data: { path: cleanPath, id: data.Id, fullPath: data.Key },
-          error: null,
-        }
-      } else {
-        const error = data
-        return { data: null, error }
+      return {
+        data: { path: cleanPath, id: data.Id, fullPath: data.Key },
+        error: null,
       }
     } catch (error) {
       if (isStorageError(error)) {
@@ -207,22 +200,16 @@ export default class StorageFileApi {
         headers['content-type'] = options.contentType as string
       }
 
-      const res = await this.fetch(url.toString(), {
-        method: 'PUT',
-        body: body as BodyInit,
-        headers,
-      })
+      const data = await put(
+        this.fetch,
+        url.toString(),
+        body,
+        { headers }
+      )
 
-      const data = await res.json()
-
-      if (res.ok) {
-        return {
-          data: { path: cleanPath, fullPath: data.Key },
-          error: null,
-        }
-      } else {
-        const error = data
-        return { data: null, error }
+      return {
+        data: { path: cleanPath, fullPath: data.Key },
+        error: null,
       }
     } catch (error) {
       if (isStorageError(error)) {

--- a/src/packages/StorageFileApi.ts
+++ b/src/packages/StorageFileApi.ts
@@ -121,7 +121,7 @@ export default class StorageFileApi {
       const data = await (method == 'PUT' ? put : post)(
         this.fetch,
         `${this.url}/object/${_path}`,
-        body,
+        body as object,
         { headers, ...(options?.duplex ? { duplex: options.duplex } : {}) }
       )
 
@@ -203,7 +203,7 @@ export default class StorageFileApi {
       const data = await put(
         this.fetch,
         url.toString(),
-        body,
+        body as object,
         { headers }
       )
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix the error handling of `upload`, `update` and `uploadToSignedUrl` APIs so that they properly return `StorageError` instead of API's error schema.

## What is the current behavior?

Multiple issues and PRs have been discussing this error for over a year. #214 #165 

There are a bunch of helper functions at `lib/fetch.ts` that catch errors returned by the server and construct `StorageError` instance. Nearly all requests are using these helpers, except for `uploadOrUpdate` and `uploadToSignedUrl` in `StorageFileApi`, making their return types inconsistent:

Typescript declarations say the error returns are like:
```typescript
{
  data: null,
  error: StorageError
}
```

However, without the helper functions, they actually return the error schema:
```typescript
{
  data: null,
  error: { error: string, message: string, statusCode: string }
}
```

## What is the new behavior?

This fix replaces raw fetch for `uploadOrUpdate` and `uploadToSignedUrl` with `post` and `put` helper functions so that their returns match the type declarations.

## Additional context

It appears upload APIs are not using helpers because `_getRequestParams` will force body to be json type, which is an easy fix.

But if you think this part should not be touched, an alternative solution could be just patch the typings.
```typescript
{
  data: null,
  error: StorageError | ErrorSchema
}
```
