### PR TITLE
fix: resolve regression with uploading files introduced by #216

### DIFF
--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -13,11 +13,13 @@ export function isStorageError(error: unknown): error is StorageError {
 
 export class StorageApiError extends StorageError {
   status: number
+  statusCode: string
 
-  constructor(message: string, status: number) {
+  constructor(message: string, status: number, statusCode: string) {
     super(message)
     this.name = 'StorageApiError'
     this.status = status
+    this.statusCode = statusCode
   }
 
   toJSON() {
@@ -25,6 +27,7 @@ export class StorageApiError extends StorageError {
       name: this.name,
       message: this.message,
       status: this.status,
+      statusCode: this.statusCode,
     }
   }
 }

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,5 +1,5 @@
 import { StorageApiError, StorageUnknownError } from './errors'
-import { resolveResponse } from './helpers'
+import { isPlainObject, resolveResponse } from './helpers'
 import { FetchParameters } from './types'
 
 export type Fetch = typeof fetch
@@ -49,11 +49,11 @@ const _getRequestParams = (
     return params
   }
 
-  if (body instanceof FormData) {
-    params.body = body
-  } else {
+  if (isPlainObject(body)) {
     params.headers = { 'Content-Type': 'application/json', ...options?.headers }
     params.body = JSON.stringify(body)
+  } else {
+    params.body = body
   }
 
   return { ...params, ...parameters }

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -27,7 +27,9 @@ const handleError = async (
     error
       .json()
       .then((err) => {
-        reject(new StorageApiError(_getErrorMessage(err), error.status || 500))
+        const status = error.status || 500
+        const statusCode = err?.statusCode || status + ''
+        reject(new StorageApiError(_getErrorMessage(err), status, statusCode))
       })
       .catch((err) => {
         reject(new StorageUnknownError(_getErrorMessage(err), err))

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -37,3 +37,23 @@ export const recursiveToCamel = (item: Record<string, any>): unknown => {
 
   return result
 }
+
+/**
+ * Determine if input is a plain object
+ * An object is plain if it's created by either {}, new Object(), or Object.create(null)
+ * source: https://github.com/sindresorhus/is-plain-obj
+ */
+export const isPlainObject = (value: object): boolean => {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  return (
+    (prototype === null ||
+      prototype === Object.prototype ||
+      Object.getPrototypeOf(prototype) === null) &&
+    !(Symbol.toStringTag in value) &&
+    !(Symbol.iterator in value)
+  )
+}

--- a/src/packages/StorageFileApi.ts
+++ b/src/packages/StorageFileApi.ts
@@ -200,12 +200,7 @@ export default class StorageFileApi {
         headers['content-type'] = options.contentType as string
       }
 
-      const data = await put(
-        this.fetch,
-        url.toString(),
-        body as object,
-        { headers }
-      )
+      const data = await put(this.fetch, url.toString(), body as object, { headers })
 
       return {
         data: { path: cleanPath, fullPath: data.Key },

--- a/test/storageFileApi.test.ts
+++ b/test/storageFileApi.test.ts
@@ -6,7 +6,7 @@ import FormData from 'form-data'
 import assert from 'assert'
 // @ts-ignore
 import fetch, { Response } from '@supabase/node-fetch'
-import { StorageError } from '../src/lib/errors'
+import { StorageApiError, StorageError } from '../src/lib/errors'
 
 // TODO: need to setup storage-api server for this test
 const URL = 'http://localhost:8000/storage/v1'
@@ -202,11 +202,10 @@ describe('Object API', () => {
       })
 
       const res = await storage.from(bucketName).upload(uploadPath, file)
-      expect(res.error).toEqual({
-        error: 'Payload too large',
-        message: 'The object exceeded the maximum allowed size',
-        statusCode: '413',
-      })
+
+      const outError = res.error as StorageApiError
+      expect(outError).toBeInstanceOf(StorageApiError)
+      expect(outError.message).toBe('The object exceeded the maximum allowed size')
     })
 
     test('can upload a file with a valid mime type', async () => {
@@ -232,11 +231,9 @@ describe('Object API', () => {
       const res = await storage.from(bucketName).upload(uploadPath, file, {
         contentType: 'image/jpeg',
       })
-      expect(res.error).toEqual({
-        error: 'invalid_mime_type',
-        message: 'mime type image/jpeg is not supported',
-        statusCode: '415',
-      })
+      const outError = res.error as StorageApiError
+      expect(outError).toBeInstanceOf(StorageApiError)
+      expect(outError.message).toBe('mime type image/jpeg is not supported')
     })
 
     test('sign url for upload', async () => {
@@ -299,11 +296,9 @@ describe('Object API', () => {
         .from(bucketName)
         .uploadToSignedUrl(data.path, data.token, file)
 
-      expect(uploadRes2.error).toEqual({
-        error: 'Duplicate',
-        message: 'The resource already exists',
-        statusCode: '409',
-      })
+      const outError = uploadRes2.error as StorageApiError
+      expect(outError).toBeInstanceOf(StorageApiError)
+      expect(outError.message).toBe('The resource already exists')
     })
   })
 

--- a/test/storageFileApi.test.ts
+++ b/test/storageFileApi.test.ts
@@ -206,6 +206,7 @@ describe('Object API', () => {
       const outError = res.error as StorageApiError
       expect(outError).toBeInstanceOf(StorageApiError)
       expect(outError.message).toBe('The object exceeded the maximum allowed size')
+      expect(outError.statusCode).toBe('413')
     })
 
     test('can upload a file with a valid mime type', async () => {
@@ -234,6 +235,7 @@ describe('Object API', () => {
       const outError = res.error as StorageApiError
       expect(outError).toBeInstanceOf(StorageApiError)
       expect(outError.message).toBe('mime type image/jpeg is not supported')
+      expect(outError.statusCode).toBe('415')
     })
 
     test('sign url for upload', async () => {
@@ -299,6 +301,7 @@ describe('Object API', () => {
       const outError = uploadRes2.error as StorageApiError
       expect(outError).toBeInstanceOf(StorageApiError)
       expect(outError.message).toBe('The resource already exists')
+      expect(outError.statusCode).toBe('409')
     })
   })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Uploading binary objects or streams results in improperly serialized data. This issue was introduced by #216 

## What is the new behavior?

Only stringify plain objects to ensure Buffer, FormData, Uint8Array, etc are handled correctly

Add `statusCode` to `StorageApiError` this gives access to the error code sent in the json payload from the storage api, and maintains the same `statusCode` values present before #216 in case anyone depends on it.

## Additional context

Issue reported in a comment on the original PR here: https://github.com/supabase/storage-js/pull/216#issuecomment-2848783707


