### PR TITLE
ci: execute release only if test passes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,15 @@ on:
       - next
       - rc
       - next-rc-1
+  workflow_run:
+    workflows: ['CI']
+    types:
+      - completed
   workflow_dispatch:
 
 jobs:
   release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Release / Node ${{ matrix.node }}
     strategy:
       matrix:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Release runs independently of tests succeeding.

## What is the new behavior?

Run release only after test completes with success status.

## Additional context

Add any other context or screenshots.
