### PR TITLE
fix: use authenticated endpoint prefixes

### DIFF
--- a/src/packages/StorageFileApi.ts
+++ b/src/packages/StorageFileApi.ts
@@ -504,7 +504,7 @@ export default class StorageFileApi {
       }
   > {
     const wantsTransformation = typeof options?.transform !== 'undefined'
-    const renderPath = wantsTransformation ? 'render/image/authenticated' : 'object'
+    const renderPath = wantsTransformation ? 'render/image/authenticated' : 'object/authenticated'
     const transformationQuery = this.transformOptsToQueryString(options?.transform || {})
     const queryString = transformationQuery ? `?${transformationQuery}` : ''
 
@@ -544,7 +544,7 @@ export default class StorageFileApi {
     const _path = this._getFinalPath(path)
 
     try {
-      const data = await get(this.fetch, `${this.url}/object/info/${_path}`, {
+      const data = await get(this.fetch, `${this.url}/object/info/authenticated/${_path}`, {
         headers: this.headers,
       })
 
@@ -577,7 +577,7 @@ export default class StorageFileApi {
     const _path = this._getFinalPath(path)
 
     try {
-      await head(this.fetch, `${this.url}/object/${_path}`, {
+      await head(this.fetch, `${this.url}/object/authenticated/${_path}`, {
         headers: this.headers,
       })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently `download()`, `exists()`, and `info()` use the `/object/:bucketName/*` routes which causes routing errors for buckets named `public` because the requests get routed to `/object/public/:bucketName/*` and the first part of the path is used as the bucket name.

This makes it impossible to perform these operations on any objects in a folder inside of a bucket named "public"

## What is the new behavior?

**storage.from('public').download('something/file.png')**

`GET /object/:bucketName/*` -> `GET /object/authenticated/:bucketName/*`

prevents routing to: `GET /object/public/:bucketName/*`


**storage.from('public').info('something/file.png')**

`GET /object/info/:bucketName/*` -> `GET /object/info/authenticated/:bucketName/*`

prevents routing to: `GET /object/info/public/:bucketName/*`


**storage.from('public').exists('something/file.png')**

`HEAD /object/:bucketName/*` -> `HEAD /object/authenticated/:bucketName/*`

prevents routing to: `HEAD /object/public/:bucketName/*`


## Additional context

A bucket with the name "public" causes issues with our api route resolution.

For example, if an object's path is public/something/file.png:

A request to /object/info/:bucketName/* routes to /object/info/public/:bucketName/* and returns a BUCKET NOT FOUND error for the bucket "something"

Also, a request to /object/:bucketName/* routes to /object/public/:bucketName/* and results in the same error
