### PR TITLE
feat: use dedicated storage host for storage lib (allows >50GB uploads)

### DIFF
--- a/src/packages/StorageBucketApi.ts
+++ b/src/packages/StorageBucketApi.ts
@@ -10,7 +10,22 @@ export default class StorageBucketApi {
   protected fetch: Fetch
 
   constructor(url: string, headers: { [key: string]: string } = {}, fetch?: Fetch) {
-    this.url = url
+    const baseUrl = new URL(url)
+
+    // if legacy uri is used, replace with new storage host (disables request buffering to allow > 50GB uploads)
+    // "project-ref.supabase.co/storage/v1" becomes "project-ref.storage.supabase.co/v1"
+    const isSupabaseHost = /supabase\.(co|in|red)$/.test(baseUrl.hostname)
+    const legacyStoragePrefix = '/storage'
+    if (
+      isSupabaseHost &&
+      !baseUrl.hostname.includes('storage.supabase.') &&
+      baseUrl.pathname.startsWith(legacyStoragePrefix)
+    ) {
+      baseUrl.pathname = baseUrl.pathname.substring(legacyStoragePrefix.length)
+      baseUrl.hostname = baseUrl.hostname.replace('supabase.', 'storage.supabase.')
+    }
+
+    this.url = baseUrl.href
     this.headers = { ...DEFAULT_HEADERS, ...headers }
     this.fetch = resolveFetch(fetch)
   }

--- a/test/storageBucketApi.test.ts
+++ b/test/storageBucketApi.test.ts
@@ -33,6 +33,43 @@ describe('Bucket API Error Handling', () => {
     jest.restoreAllMocks()
   })
 
+  describe('URL Construction', () => {
+    const urlTestCases = [
+      [
+        'https://blah.supabase.co/storage/v1',
+        'https://blah.storage.supabase.co/v1',
+        'update legacy prod host to new host',
+      ],
+      [
+        'https://blah.supabase.red/storage/v1',
+        'https://blah.storage.supabase.red/v1',
+        'update legacy staging host to new host',
+      ],
+      [
+        'https://blah.storage.supabase.co/v1',
+        'https://blah.storage.supabase.co/v1',
+        'accept new host without modification',
+      ],
+      [
+        'https://blah.supabase.co.example.com/storage/v1',
+        'https://blah.supabase.co.example.com/storage/v1',
+        'not modify non-platform hosts',
+      ],
+      [
+        'http://localhost:1234/storage/v1',
+        'http://localhost:1234/storage/v1',
+        'support local host with port without modification',
+      ],
+    ]
+
+    urlTestCases.forEach(([inputUrl, expectUrl, description]) => {
+      it('should ' + description, () => {
+        const storage = new StorageClient(inputUrl, { apikey: KEY })
+        expect(storage['url']).toBe(expectUrl)
+      })
+    })
+  })
+
   describe('listBuckets', () => {
     it('handles network errors', async () => {
       const mockError = new Error('Network failure')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Storage lib is initialized using the same host as all other Supabase APIs. This zone does not allow uploading of large files.

## What is the new behavior?

Initialize storage lib using new `project-ref.storage.supabase.co/v1` URI which supports uploads up to 500GB

## Additional context

This is specific to the Supabase infrastructure

`project-ref.supabase.co/storage/v1` -> `project-ref.storage.supabase.co/v1`


