### PR TITLE
fix: bucket type, iceberg_catalog property

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,6 +4,7 @@ export interface Bucket {
   owner: string
   file_size_limit?: number
   allowed_mime_types?: string[]
+  iceberg_catalog?: boolean
   created_at: string
   updated_at: string
   public: boolean


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`iceberg_catalog` is not included in the `Bucket` type

## What is the new behavior?

`iceberg_catalog`  is not included
