### PR TITLE
fix: optionally use storage new hostname

### DIFF
--- a/src/StorageClient.ts
+++ b/src/StorageClient.ts
@@ -3,8 +3,13 @@ import StorageBucketApi from './packages/StorageBucketApi'
 import { Fetch } from './lib/fetch'
 
 export class StorageClient extends StorageBucketApi {
-  constructor(url: string, headers: { [key: string]: string } = {}, fetch?: Fetch) {
-    super(url, headers, fetch)
+  constructor(
+    url: string,
+    headers: { [key: string]: string } = {},
+    fetch?: Fetch,
+    opts?: { useNewHostname?: boolean }
+  ) {
+    super(url, headers, fetch, opts)
   }
 
   /**

--- a/src/packages/StorageBucketApi.ts
+++ b/src/packages/StorageBucketApi.ts
@@ -9,20 +9,27 @@ export default class StorageBucketApi {
   protected headers: { [key: string]: string }
   protected fetch: Fetch
 
-  constructor(url: string, headers: { [key: string]: string } = {}, fetch?: Fetch) {
+  constructor(
+    url: string,
+    headers: { [key: string]: string } = {},
+    fetch?: Fetch,
+    opts?: { useNewHostname?: boolean }
+  ) {
     const baseUrl = new URL(url)
 
     // if legacy uri is used, replace with new storage host (disables request buffering to allow > 50GB uploads)
     // "project-ref.supabase.co/storage/v1" becomes "project-ref.storage.supabase.co/v1"
-    const isSupabaseHost = /supabase\.(co|in|red)$/.test(baseUrl.hostname)
-    const legacyStoragePrefix = '/storage'
-    if (
-      isSupabaseHost &&
-      !baseUrl.hostname.includes('storage.supabase.') &&
-      baseUrl.pathname.startsWith(legacyStoragePrefix)
-    ) {
-      baseUrl.pathname = baseUrl.pathname.substring(legacyStoragePrefix.length)
-      baseUrl.hostname = baseUrl.hostname.replace('supabase.', 'storage.supabase.')
+    if (opts?.useNewHostname) {
+      const isSupabaseHost = /supabase\.(co|in|red)$/.test(baseUrl.hostname)
+      const legacyStoragePrefix = '/storage'
+      if (
+        isSupabaseHost &&
+        !baseUrl.hostname.includes('storage.supabase.') &&
+        baseUrl.pathname.startsWith(legacyStoragePrefix)
+      ) {
+        baseUrl.pathname = baseUrl.pathname.substring(legacyStoragePrefix.length)
+        baseUrl.hostname = baseUrl.hostname.replace('supabase.', 'storage.supabase.')
+      }
     }
 
     this.url = baseUrl.href

--- a/test/storageBucketApi.test.ts
+++ b/test/storageBucketApi.test.ts
@@ -64,7 +64,9 @@ describe('Bucket API Error Handling', () => {
 
     urlTestCases.forEach(([inputUrl, expectUrl, description]) => {
       it('should ' + description, () => {
-        const storage = new StorageClient(inputUrl, { apikey: KEY })
+        const storage = new StorageClient(inputUrl, { apikey: KEY }, undefined, {
+          useNewHostname: true,
+        })
         expect(storage['url']).toBe(expectUrl)
       })
     })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Opt-in behaviour of using the new storage hostname 
