### PR TITLE
fix: consistent bucket type name

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type BucketType = 'STANDARD' | 'ICEBERG'
+export type BucketType = 'STANDARD' | 'ANALYTICS'
 
 export interface Bucket {
   id: string


### PR DESCRIPTION
## What kind of change does this PR introduce?

Preview Feature

## What is the new behavior?

changed bucket type to `ANALYTICS`