### PR TITLE
fix: use normal storage/v1 prefix with storage zone

### DIFF
--- a/src/StorageClient.ts
+++ b/src/StorageClient.ts
@@ -2,12 +2,16 @@ import StorageFileApi from './packages/StorageFileApi'
 import StorageBucketApi from './packages/StorageBucketApi'
 import { Fetch } from './lib/fetch'
 
+export interface StorageClientOptions {
+  useNewHostname?: boolean
+}
+
 export class StorageClient extends StorageBucketApi {
   constructor(
     url: string,
     headers: { [key: string]: string } = {},
     fetch?: Fetch,
-    opts?: { useNewHostname?: boolean }
+    opts?: StorageClientOptions
   ) {
     super(url, headers, fetch, opts)
   }

--- a/src/packages/StorageBucketApi.ts
+++ b/src/packages/StorageBucketApi.ts
@@ -3,6 +3,7 @@ import { isStorageError, StorageError } from '../lib/errors'
 import { Fetch, get, post, put, remove } from '../lib/fetch'
 import { resolveFetch } from '../lib/helpers'
 import { Bucket, BucketType } from '../lib/types'
+import { StorageClientOptions } from '../StorageClient'
 
 export default class StorageBucketApi {
   protected url: string
@@ -13,21 +14,15 @@ export default class StorageBucketApi {
     url: string,
     headers: { [key: string]: string } = {},
     fetch?: Fetch,
-    opts?: { useNewHostname?: boolean }
+    opts?: StorageClientOptions
   ) {
     const baseUrl = new URL(url)
 
     // if legacy uri is used, replace with new storage host (disables request buffering to allow > 50GB uploads)
-    // "project-ref.supabase.co/storage/v1" becomes "project-ref.storage.supabase.co/v1"
+    // "project-ref.supabase.co" becomes "project-ref.storage.supabase.co"
     if (opts?.useNewHostname) {
       const isSupabaseHost = /supabase\.(co|in|red)$/.test(baseUrl.hostname)
-      const legacyStoragePrefix = '/storage'
-      if (
-        isSupabaseHost &&
-        !baseUrl.hostname.includes('storage.supabase.') &&
-        baseUrl.pathname.startsWith(legacyStoragePrefix)
-      ) {
-        baseUrl.pathname = baseUrl.pathname.substring(legacyStoragePrefix.length)
+      if (isSupabaseHost && !baseUrl.hostname.includes('storage.supabase.')) {
         baseUrl.hostname = baseUrl.hostname.replace('supabase.', 'storage.supabase.')
       }
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When `useNewHostname` is true the path is changed from `storage/v1` to `v1`, but it should be preserved

## What is the new behavior?

When `useNewHostname` is true update the host name to `ref.storage.supabase.co`, but leave the path as-is

Export `StorageClientOptions` so it can be used by supabase-js.

## Additional context

This is to support large uploads by bypassing "request buffering" the path `/storage/v1` is used in monitoring to identify storage requests so we need to default to keeping it.
