### PR TITLE
chore: include search limit to jsdoc

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -80,7 +80,8 @@ export interface DestinationOptions {
 
 export interface SearchOptions {
   /**
-   *  The number of files you want to be returned.
+   * The number of files you want to be returned.
+   * @default 100
    */
   limit?: number
 

--- a/src/packages/StorageFileApi.ts
+++ b/src/packages/StorageFileApi.ts
@@ -736,6 +736,7 @@ export default class StorageFileApi {
   /**
    * Lists all the files within a bucket.
    * @param path The folder path.
+   * @param options Search options including limit (defaults to 100), offset, sortBy, and search
    */
   async list(
     path?: string,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add in JSDoc the default limit, so that it gets added to the docs as well.

## What is the current behavior?

The default limit is not in JSDoc or the docs.

## What is the new behavior?

The default limit is in JSDoc and the docs.

## Additional context

User asked it [here](https://github.com/supabase/storage-js/issues/239).
