### PR TITLE
fix: trim duplicate slashes from file paths

### DIFF
--- a/src/packages/StorageFileApi.ts
+++ b/src/packages/StorageFileApi.ts
@@ -783,7 +783,7 @@ export default class StorageFileApi {
   }
 
   private _getFinalPath(path: string) {
-    return `${this.bucketId}/${path}`
+    return `${this.bucketId}/${path.replace(/^\/+/, '')}`
   }
 
   private _removeEmptyFolders(path: string) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If an object path starts with a slash the final path includes a duplicate slash

## What is the new behavior?

Trim any leading slashes from the path to avoid duplicate slashes

## Additional context

Currently, if you click `Get URL` on a public URL in the dashboard the url has duplicate slashes between the bucket name and object path. The URL still works fine, but this little bug always annoyed me.

Example public url: `https://project-ref.supabase.co/storage/v1/object/public/my-public-bucket//my-image.png`
