### PR TITLE
chore: add preview release

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,0 +1,36 @@
+name: Preview release
+
+permissions:
+  pull-requests: write
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, labeled]
+
+jobs:
+  preview:
+    if: >
+      github.repository == 'supabase/storage-js' &&
+      (github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger: preview')))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - run: npx pkg-pr-new@latest publish --compact

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # `storage-js`
 
+<div align="center">
+
+[![pkg.pr.new](https://pkg.pr.new/badge/supabase/storage-js)](https://pkg.pr.new/~/supabase/storage-js)
+
+</div>
+
 JS Client library to interact with Supabase Storage.
 
 - Documentation: https://supabase.io/docs/reference/javascript/storage-createbucket


### PR DESCRIPTION
## What kind of change does this PR introduce?

Infrastructure improvement - adds a preview release workflow for easier testing of changes.

## What is the current behavior?

Contributors and maintainers need to manually build and test changes locally or wait for official releases to test package changes.

## What is the new behavior?

- Adds automated preview release workflow using [`pkg.pr.new`](https://github.com/stackblitz-labs/pkg.pr.new)
- Triggers on pushes to `master` branch and PRs with the `trigger: preview` label
- Automatically publishes preview packages that can be installed and tested
- Provides temporary package URLs for quick testing without affecting the main package

## Additional context

This workflow allows for:
- Quick testing of PR changes before merging
- Easy collaboration on features by sharing preview package links
- Reduced friction in the development and review process

The workflow uses the `trigger: preview` label to control when preview releases are created for PRs, preventing unnecessary builds while allowing on-demand testing.