### PR TITLE
add support for .throwOnError()

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,21 @@ const storageClient = new StorageClient(STORAGE_URL, {
   const { data, error } = await storageClient.from('public-bucket').getPublicUrl('path/to/file')
   ```
 
+### Error Handling
+
+Supplying `.throwOnError()` will throw errors instead of returning them as a property on the response object.
+
+  ```js
+  try {
+    const { data } = await storageClient
+      .from('bucket')
+      .throwOnError()
+      .download('path/to/file')
+  } catch (error) {
+    console.error(error)
+  }
+  ```
+
 ## Sponsors
 
 We are building the features of Firebase using enterprise-grade, open source products. We support existing communities wherever possible, and if the products don’t exist we build them and open source them ourselves. Thanks to these sponsors who are making the OSS ecosystem better for everyone.

--- a/src/packages/StorageBucketApi.ts
+++ b/src/packages/StorageBucketApi.ts
@@ -9,6 +9,7 @@ export default class StorageBucketApi {
   protected url: string
   protected headers: { [key: string]: string }
   protected fetch: Fetch
+  protected shouldThrowOnError = false
 
   constructor(
     url: string,
@@ -33,6 +34,14 @@ export default class StorageBucketApi {
   }
 
   /**
+   * Enable throwing errors instead of returning them.
+   */
+  public throwOnError(): this {
+    this.shouldThrowOnError = true
+    return this
+  }
+
+  /**
    * Retrieves the details of all Storage buckets within an existing project.
    */
   async listBuckets(): Promise<
@@ -49,6 +58,9 @@ export default class StorageBucketApi {
       const data = await get(this.fetch, `${this.url}/bucket`, { headers: this.headers })
       return { data, error: null }
     } catch (error) {
+      if (this.shouldThrowOnError) {
+        throw error
+      }
       if (isStorageError(error)) {
         return { data: null, error }
       }
@@ -78,6 +90,9 @@ export default class StorageBucketApi {
       const data = await get(this.fetch, `${this.url}/bucket/${id}`, { headers: this.headers })
       return { data, error: null }
     } catch (error) {
+      if (this.shouldThrowOnError) {
+        throw error
+      }
       if (isStorageError(error)) {
         return { data: null, error }
       }
@@ -137,6 +152,9 @@ export default class StorageBucketApi {
       )
       return { data, error: null }
     } catch (error) {
+      if (this.shouldThrowOnError) {
+        throw error
+      }
       if (isStorageError(error)) {
         return { data: null, error }
       }
@@ -189,6 +207,9 @@ export default class StorageBucketApi {
       )
       return { data, error: null }
     } catch (error) {
+      if (this.shouldThrowOnError) {
+        throw error
+      }
       if (isStorageError(error)) {
         return { data: null, error }
       }
@@ -223,6 +244,9 @@ export default class StorageBucketApi {
       )
       return { data, error: null }
     } catch (error) {
+      if (this.shouldThrowOnError) {
+        throw error
+      }
       if (isStorageError(error)) {
         return { data: null, error }
       }
@@ -258,6 +282,9 @@ export default class StorageBucketApi {
       )
       return { data, error: null }
     } catch (error) {
+      if (this.shouldThrowOnError) {
+        throw error
+      }
       if (isStorageError(error)) {
         return { data: null, error }
       }

--- a/src/packages/StorageFileApi.ts
+++ b/src/packages/StorageFileApi.ts
@@ -46,6 +46,7 @@ export default class StorageFileApi {
   protected headers: { [key: string]: string }
   protected bucketId?: string
   protected fetch: Fetch
+  protected shouldThrowOnError = false
 
   constructor(
     url: string,
@@ -57,6 +58,14 @@ export default class StorageFileApi {
     this.headers = headers
     this.bucketId = bucketId
     this.fetch = resolveFetch(fetch)
+  }
+
+  /**
+   * Enable throwing errors instead of returning them.
+   */
+  public throwOnError(): this {
+    this.shouldThrowOnError = true
+    return this
   }
 
   /**
@@ -132,6 +141,9 @@ export default class StorageFileApi {
         error: null,
       }
     } catch (error) {
+      if (this.shouldThrowOnError) {
+        throw error
+      }
       if (isStorageError(error)) {
         return { data: null, error }
       }
@@ -209,6 +221,9 @@ export default class StorageFileApi {
         error: null,
       }
     } catch (error) {
+      if (this.shouldThrowOnError) {
+        throw error
+      }
       if (isStorageError(error)) {
         return { data: null, error }
       }
@@ -263,6 +278,9 @@ export default class StorageFileApi {
 
       return { data: { signedUrl: url.toString(), path, token }, error: null }
     } catch (error) {
+      if (this.shouldThrowOnError) {
+        throw error
+      }
       if (isStorageError(error)) {
         return { data: null, error }
       }
@@ -339,6 +357,9 @@ export default class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
+      if (this.shouldThrowOnError) {
+        throw error
+      }
       if (isStorageError(error)) {
         return { data: null, error }
       }
@@ -382,6 +403,9 @@ export default class StorageFileApi {
       )
       return { data: { path: data.Key }, error: null }
     } catch (error) {
+      if (this.shouldThrowOnError) {
+        throw error
+      }
       if (isStorageError(error)) {
         return { data: null, error }
       }
@@ -428,6 +452,9 @@ export default class StorageFileApi {
       data = { signedUrl }
       return { data, error: null }
     } catch (error) {
+      if (this.shouldThrowOnError) {
+        throw error
+      }
       if (isStorageError(error)) {
         return { data: null, error }
       }
@@ -478,6 +505,9 @@ export default class StorageFileApi {
         error: null,
       }
     } catch (error) {
+      if (this.shouldThrowOnError) {
+        throw error
+      }
       if (isStorageError(error)) {
         return { data: null, error }
       }
@@ -519,6 +549,9 @@ export default class StorageFileApi {
       const data = await res.blob()
       return { data, error: null }
     } catch (error) {
+      if (this.shouldThrowOnError) {
+        throw error
+      }
       if (isStorageError(error)) {
         return { data: null, error }
       }
@@ -552,6 +585,9 @@ export default class StorageFileApi {
 
       return { data: recursiveToCamel(data) as Camelize<FileObjectV2>, error: null }
     } catch (error) {
+      if (this.shouldThrowOnError) {
+        throw error
+      }
       if (isStorageError(error)) {
         return { data: null, error }
       }
@@ -585,6 +621,9 @@ export default class StorageFileApi {
 
       return { data: true, error: null }
     } catch (error) {
+      if (this.shouldThrowOnError) {
+        throw error
+      }
       if (isStorageError(error) && error instanceof StorageUnknownError) {
         const originalError = (error.originalError as unknown) as { status: number }
 
@@ -765,6 +804,9 @@ export default class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
+      if (this.shouldThrowOnError) {
+        throw error
+      }
       if (isStorageError(error)) {
         return { data: null, error }
       }
@@ -802,6 +844,9 @@ export default class StorageFileApi {
       )
       return { data, error: null }
     } catch (error) {
+      if (this.shouldThrowOnError) {
+        throw error
+      }
       if (isStorageError(error)) {
         return { data: null, error }
       }

--- a/test/storageBucketApi.test.ts
+++ b/test/storageBucketApi.test.ts
@@ -85,6 +85,9 @@ describe('Bucket API Error Handling', () => {
       expect(data).toBeNull()
       expect(error).not.toBeNull()
       expect(error?.message).toBe(`headers must have required property 'authorization'`)
+
+      // should throw when .throwOnError is enabled
+      await expect(storage.throwOnError().listBuckets()).rejects.toThrowError()
     })
 
     it('handles network errors', async () => {

--- a/test/storageFileApi.test.ts
+++ b/test/storageFileApi.test.ts
@@ -432,6 +432,11 @@ describe('Object API', () => {
 
       const resNotExists = await storage.from(bucketName).exists('do-not-exists')
       expect(resNotExists.data).toEqual(false)
+
+      // should throw when .throwOnError is enabled
+      await expect(
+        storage.from(bucketName).throwOnError().exists('do-not-exists')
+      ).rejects.toThrowError()
     })
   })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds support for `.throwOnError()` (see: https://github.com/supabase/storage-js/issues/150, https://github.com/supabase/supabase-js/issues/92)

## What is the current behavior?

Errors are not thrown and instead a response object is returned with `data` and `error` properties.

## What is the new behavior?

When `.throwOnError()` is supplied, errors are thrown.

## Additional context

This is disabled by default as it's a breaking change. This follows the identical function added in https://github.com/supabase/postgrest-js/pull/188.