### PR TITLE
fix: export storageClientOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
-export { StorageClient as StorageClient } from './StorageClient'
+export { StorageClient } from './StorageClient'
+export type { StorageClientOptions } from './StorageClient'
 export * from './lib/types'
 export * from './lib/errors'


### PR DESCRIPTION
Export `storageClientOptions`, so that we can remove the deep import and get CI working again!

Ref: https://github.com/supabase/supabase-js/pull/1567