### PR TITLE
fix(storage): correct exists() error handling for non-existent files …

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,20 +156,24 @@ const storageClient = new StorageClient(STORAGE_URL, {
   const { data, error } = await storageClient.from('public-bucket').getPublicUrl('path/to/file')
   ```
 
+- Check if a file exists:
+
+  ```js
+  const { data, error } = await storageClient.from('bucket').exists('path/to/file')
+  // data will be true if the file exists, false otherwise
+  ```
+
 ### Error Handling
 
 Supplying `.throwOnError()` will throw errors instead of returning them as a property on the response object.
 
-  ```js
-  try {
-    const { data } = await storageClient
-      .from('bucket')
-      .throwOnError()
-      .download('path/to/file')
-  } catch (error) {
-    console.error(error)
-  }
-  ```
+```js
+try {
+  const { data } = await storageClient.from('bucket').throwOnError().download('path/to/file')
+} catch (error) {
+  console.error(error)
+}
+```
 
 ## Sponsors
 

--- a/src/packages/StorageFileApi.ts
+++ b/src/packages/StorageFileApi.ts
@@ -1,4 +1,4 @@
-import { isStorageError, StorageError, StorageUnknownError } from '../lib/errors'
+import { isStorageError, StorageError, StorageUnknownError, StorageApiError } from '../lib/errors'
 import { Fetch, get, head, post, put, remove } from '../lib/fetch'
 import { recursiveToCamel, resolveFetch } from '../lib/helpers'
 import {
@@ -604,11 +604,19 @@ export default class StorageFileApi {
       if (this.shouldThrowOnError) {
         throw error
       }
-      if (isStorageError(error) && error instanceof StorageUnknownError) {
-        const originalError = (error.originalError as unknown) as { status: number }
+      if (isStorageError(error)) {
+        // Check for both StorageApiError (which has status directly) and StorageUnknownError (with originalError)
+        let status: number | undefined
 
-        if ([400, 404].includes(originalError?.status)) {
-          return { data: false, error }
+        if (error instanceof StorageApiError) {
+          status = error.status
+        } else if (error instanceof StorageUnknownError) {
+          const originalError = (error.originalError as unknown) as { status: number }
+          status = originalError?.status
+        }
+
+        if (status && [400, 404].includes(status)) {
+          return { data: false, error: null }
         }
       }
 


### PR DESCRIPTION
…(supabase#253)

# Bug Fix Report

I have successfully identified and fixed the bug reported in the
issue. Here's what I found and resolved:

## The Issue
The bug report was partially correct. The `exists` method was indeed
present in both browser and Node.js builds (I confirmed it existed
in the compiled output), but there was an error handling bug that
made it appear to not work properly in certain cases.

## The Root Cause
The problem was in the error handling logic of the `exists` method in
`src/packages/StorageFileApi.ts`. When a file doesn't exist
(resulting in a 404 HTTP status), the method would return `{ data: 
false, error: StorageError }` instead of `{ data: false, error: null }`.  
This was incorrect behavior because:

1. The operation (checking for existence) was successful  
2. Getting a 404 simply means the file doesn't exist, not that the
   operation failed  
3. The user should receive `{ data: false, error: null }` to indicate
   "file doesn't exist, but the check was successful"

## The Fix
I updated the `exists` method to properly handle both
`StorageApiError` (which contains the status code directly) and
`StorageUnknownError` (which contains the original error object),
and return `{ data: false, error: null }` when the error status is
400 or 404.

## Changes Made
1. Fixed error handling in the `exists` method to properly return `{ 
   data: false, error: null }` when a file doesn't exist  
2. Added proper TypeScript imports for `StorageApiError`  
3. Updated README documentation with an example of how to use the
   `exists` method  

## Verification
- The project builds successfully with the fix  
- The method is available in all builds (main, module, UMD)  
- The fix aligns with the existing test expectations  
- Proper TypeScript types are maintained  

